### PR TITLE
Fix ModKeys casting for multiple modifiers support

### DIFF
--- a/ClassicAssist/Engine.cs
+++ b/ClassicAssist/Engine.cs
@@ -257,7 +257,7 @@ namespace Assistant
 
             if ( pressed )
             {
-                bool pass = HotkeyManager.GetInstance().OnHotkeyPressed( keys, (ModKey) mod );
+                bool pass = HotkeyManager.GetInstance().OnHotkeyPressed( keys, IntToModKey( mod ) );
 
                 return !pass;
             }

--- a/ClassicAssist/Misc/SDLKeys.cs
+++ b/ClassicAssist/Misc/SDLKeys.cs
@@ -787,6 +787,12 @@ namespace ClassicAssist.Misc
             return Key.None;
         }
 
+        public static ModKey IntToModKey( int mod )
+        {
+            return (ModKey) ( mod & (int) ( ModKey.RightAlt | ModKey.RightCtrl | ModKey.RightShift | ModKey.LeftAlt |
+                                            ModKey.LeftCtrl | ModKey.LeftShift ) );
+        }
+
         public static SDL_Keycode SDL_SCANCODE_TO_KEYCODE( SDL_Scancode X )
         {
             return (SDL_Keycode) ( (int) X | SDLK_SCANCODE_MASK );


### PR DESCRIPTION
If capslock, numlock, etc are active when hitting a normal keypress, it sets the modifier for that key as well. Fixed by only using the available modifiers that's used in the plugin.

Fixes: #85 