### PR TITLE
Scavenger using item flag 0x32

### DIFF
--- a/ClassicAssist/Data/Autoloot/AutolootPriority.cs
+++ b/ClassicAssist/Data/Autoloot/AutolootPriority.cs
@@ -21,6 +21,8 @@ namespace ClassicAssist.Data.Autoloot
     {
         Low,
         Normal,
-        High
+        Medium,
+        High,
+        Top,
     }
 }

--- a/ClassicAssist/Data/Macros/Commands/MobileCommands.cs
+++ b/ClassicAssist/Data/Macros/Commands/MobileCommands.cs
@@ -306,7 +306,24 @@ namespace ClassicAssist.Data.Macros.Commands
         [CommandsDisplay( Category = nameof( Strings.Entity ) )]
         public static int MaxWeight()
         {
-            return Engine.Player?.WeightMax ?? 0;
+            PlayerMobile player = Engine.Player;
+            int res = 0;
+
+            try
+            {
+                res = player.WeightMax;
+                if (res == 0)
+                {
+                    //Calculate maxweight of player // pre-UOR 
+                    //For Gargoyles and Elves, 125 Strength gives a carrying capacity of 477 stones. Humans have the Strong Back racial ability that allows them to carry an additional 60 stones. Thus, for Humans, 125 Strength gives a carrying capacity of 537 stones. Each point of strength adds 3.5 stones carrying capacity: 
+                    //https://www.uoguide.com/Weight
+                    //MaxWeight = (((Race == Human) ? 100 : 40) + (int)(3.5 * Strength))
+                    res = (40 + ((int)(3.5 * player.Strength)));
+                }
+            }
+            catch { }
+
+            return res;
         }
 
         [CommandsDisplay( Category = nameof( Strings.Entity ) )]

--- a/ClassicAssist/Data/Scavenger/ScavengerEntry.cs
+++ b/ClassicAssist/Data/Scavenger/ScavengerEntry.cs
@@ -9,6 +9,7 @@ namespace ClassicAssist.Data.Scavenger
         private bool _enabled;
         private int _graphic;
         private int _hue;
+        private int _flag;
         private string _name;
         private ScavengerPriority _priority = ScavengerPriority.Normal;
 
@@ -28,6 +29,12 @@ namespace ClassicAssist.Data.Scavenger
         {
             get => _hue;
             set => SetProperty( ref _hue, value );
+        }
+
+        public int Flag
+        {
+            get => _flag;
+            set => SetProperty(ref _flag, value);
         }
 
         public string Name

--- a/ClassicAssist/Data/Scavenger/ScavengerPriority.cs
+++ b/ClassicAssist/Data/Scavenger/ScavengerPriority.cs
@@ -21,6 +21,8 @@ namespace ClassicAssist.Data.Scavenger
     {
         Low,
         Normal,
-        High
+        Medium,
+        High,
+        Top,
     }
 }

--- a/ClassicAssist/UI/ViewModels/Agents/ScavengerTabViewModel.cs
+++ b/ClassicAssist/UI/ViewModels/Agents/ScavengerTabViewModel.cs
@@ -205,8 +205,8 @@ namespace ClassicAssist.UI.ViewModels.Agents
                     }
 
                     Item[] matches = Engine.Items.SelectEntities( i =>
-                        i.Distance <= SCAVENGER_DISTANCE && i.Owner == 0 && i.ID == entry.Graphic &&
-                        ( entry.Hue == -1 || i.Hue == entry.Hue ) && !_ignoreList.Contains( i.Serial ) );
+                          i.Distance <= SCAVENGER_DISTANCE && i.Owner == 0 && ( i.Flags == entry.Flag || i.Flags == 32 ) && i.ID == entry.Graphic &&
+                          (entry.Hue == -1 || i.Hue == entry.Hue) && !_ignoreList.Contains(i.Serial));
 
                     if ( matches == null )
                     {
@@ -233,7 +233,7 @@ namespace ClassicAssist.UI.ViewModels.Agents
                 {
                     UOC.SystemMessage( string.Format( Strings.Scavenging___0__, scavengerItem.Name ?? "Unknown" ), 61 );
                     Task<bool> t = ActionPacketQueue.EnqueueDragDrop( scavengerItem.Serial, scavengerItem.Count,
-                        container.Serial, QueuePriority.Low, true, true, requeueOnFailure: false,
+                        container.Serial, QueuePriority.High, true, true, requeueOnFailure: false, attempt: 2,
                         successPredicate: CheckItemContainer );
 
                     if ( t.Result && CheckItemContainer( scavengerItem.Serial, container.Serial ) )
@@ -272,7 +272,7 @@ namespace ClassicAssist.UI.ViewModels.Agents
             string tiledataName = TileData.GetStaticTile( item.ID ).Name ?? "Unknown";
 
             ScavengerEntry entry =
-                new ScavengerEntry { Enabled = true, Graphic = item.ID, Hue = item.Hue, Name = tiledataName };
+                new ScavengerEntry { Enabled = true, Graphic = item.ID, Hue = item.Hue, Flag = item.Flags, Name = tiledataName };
 
             Items.Add( entry );
         }


### PR DESCRIPTION
 prevent scavenging locked down items using item flag 0x32 

seems to be scavenging faster now while mounted