### PR TITLE
fixed TargetNextFriend -> TargetFriendType.Only

### DIFF
--- a/ClassicAssist/Data/Hotkeys/Commands/TargetAcquisitionFriend.cs
+++ b/ClassicAssist/Data/Hotkeys/Commands/TargetAcquisitionFriend.cs
@@ -29,7 +29,7 @@ namespace ClassicAssist.Data.Hotkeys.Commands
             public override void Execute()
             {
                 TargetManager.GetInstance()
-                    .GetFriend( TargetNotoriety.Any, TargetBodyType.Any, TargetDistance.Next );
+                    .GetFriend( TargetNotoriety.Any, TargetBodyType.Any, TargetDistance.Next , TargetFriendType.Only);
             }
         }
 


### PR DESCRIPTION
only select mobiles from friends list when clicking AcquireNextFriend(be it red criminals blue or grey)... otherwise use AcquireNextInnocent hotkey