### PR TITLE
Fix new macro group not displaying

### DIFF
--- a/ClassicAssist/Data/Macros/Commands/EntityCommands.cs
+++ b/ClassicAssist/Data/Macros/Commands/EntityCommands.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using Assistant;
 using ClassicAssist.Data.BuffIcons;
 using ClassicAssist.Data.SpecialMoves;
@@ -26,6 +27,14 @@ namespace ClassicAssist.Data.Macros.Commands
             Entity entity = Engine.Items.GetItem( serial ) ?? (Entity) Engine.Mobiles.GetMobile( serial );
 
             return entity?.Distance ?? int.MaxValue;
+        }
+
+        // ReSharper disable once ExplicitCallerInfoArgument
+        [CommandsDisplay( "DistanceCoordinates", Category = nameof( Strings.Entity ),
+            Parameters = new[] { nameof( ParameterType.XCoordinate ), nameof( ParameterType.YCoordinate ) } )]
+        public static int Distance( int x, int y )
+        {
+            return Math.Max( Math.Abs( x - Engine.Player?.X ?? x ), Math.Abs( y - Engine.Player?.Y ?? y ) );
         }
 
         [CommandsDisplay( Category = nameof( Strings.Entity ),

--- a/ClassicAssist/Data/Macros/Commands/SkillCommands.cs
+++ b/ClassicAssist/Data/Macros/Commands/SkillCommands.cs
@@ -55,6 +55,17 @@ namespace ClassicAssist.Data.Macros.Commands
 
         [CommandsDisplay( Category = nameof( Strings.Skills ),
             Parameters = new[] { nameof( ParameterType.SkillName ) } )]
+        public static double SkillDelta( string name )
+        {
+            SkillManager manager = SkillManager.GetInstance();
+
+            SkillEntry s = manager.Items.FirstOrDefault( se => se.Skill.Name.ToLower().Contains( name.ToLower() ) );
+
+            return s?.Delta ?? 0;
+        }
+
+        [CommandsDisplay( Category = nameof( Strings.Skills ),
+            Parameters = new[] { nameof( ParameterType.SkillName ) } )]
         public static double SkillCap( string name )
         {
             SkillManager manager = SkillManager.GetInstance();

--- a/ClassicAssist/Resources/MacroCommandHelp.Designer.cs
+++ b/ClassicAssist/Resources/MacroCommandHelp.Designer.cs
@@ -903,6 +903,37 @@ namespace ClassicAssist.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Returns the distance to the given coordinates..
+        /// </summary>
+        public static string DISTANCECOORDINATES_COMMAND_DESCRIPTION {
+            get {
+                return ResourceManager.GetString("DISTANCECOORDINATES_COMMAND_DESCRIPTION", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to location = (1000, 1000, 0)
+        ///
+        ///while Distance(location[0], location[1]):
+        /// Pathfind(location[0], location[1], location[2])
+        /// Pause(1000).
+        /// </summary>
+        public static string DISTANCECOORDINATES_COMMAND_EXAMPLE {
+            get {
+                return ResourceManager.GetString("DISTANCECOORDINATES_COMMAND_EXAMPLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Distance(1000, 1000).
+        /// </summary>
+        public static string DISTANCECOORDINATES_COMMAND_INSERTTEXT {
+            get {
+                return ResourceManager.GetString("DISTANCECOORDINATES_COMMAND_INSERTTEXT", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Dress all items in the specified dress agent..
         /// </summary>
         public static string DRESS_COMMAND_DESCRIPTION {
@@ -3429,6 +3460,34 @@ namespace ClassicAssist.Resources {
         public static string SKILLCAP_COMMAND_INSERTTEXT {
             get {
                 return ResourceManager.GetString("SKILLCAP_COMMAND_INSERTTEXT", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Returns the skill value delta since last reset.
+        /// </summary>
+        public static string SKILLDELTA_COMMAND_DESCRIPTION {
+            get {
+                return ResourceManager.GetString("SKILLDELTA_COMMAND_DESCRIPTION", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to if SkillDelta(&apos;Hiding&apos;) &gt; 0.5:
+        ///    Stop().
+        /// </summary>
+        public static string SKILLDELTA_COMMAND_EXAMPLE {
+            get {
+                return ResourceManager.GetString("SKILLDELTA_COMMAND_EXAMPLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SkillDelta(&apos;skillName&apos;).
+        /// </summary>
+        public static string SKILLDELTA_COMMAND_INSERTTEXT {
+            get {
+                return ResourceManager.GetString("SKILLDELTA_COMMAND_INSERTTEXT", resourceCulture);
             }
         }
         

--- a/ClassicAssist/Resources/MacroCommandHelp.resx
+++ b/ClassicAssist/Resources/MacroCommandHelp.resx
@@ -1682,4 +1682,27 @@ else:
   <data name="AUTOLOOT_COMMAND_INSERTTEXT" xml:space="preserve">
     <value>Autoloot("found")</value>
   </data>
+  <data name="DISTANCECOORDINATES_COMMAND_DESCRIPTION" xml:space="preserve">
+    <value>Returns the distance to the given coordinates.</value>
+  </data>
+  <data name="DISTANCECOORDINATES_COMMAND_INSERTTEXT" xml:space="preserve">
+    <value>Distance(1000, 1000)</value>
+  </data>
+  <data name="DISTANCECOORDINATES_COMMAND_EXAMPLE" xml:space="preserve">
+    <value>location = (1000, 1000, 0)
+
+while Distance(location[0], location[1]):
+ Pathfind(location[0], location[1], location[2])
+ Pause(1000)</value>
+  </data>
+  <data name="SKILLDELTA_COMMAND_DESCRIPTION" xml:space="preserve">
+    <value>Returns the skill value delta since last reset</value>
+  </data>
+  <data name="SKILLDELTA_COMMAND_INSERTTEXT" xml:space="preserve">
+    <value>SkillDelta('skillName')</value>
+  </data>
+  <data name="SKILLDELTA_COMMAND_EXAMPLE" xml:space="preserve">
+    <value>if SkillDelta('Hiding') &gt; 0.5:
+    Stop()</value>
+  </data>
 </root>

--- a/ClassicAssist/UI/ViewModels/MacrosTabViewModel.cs
+++ b/ClassicAssist/UI/ViewModels/MacrosTabViewModel.cs
@@ -436,6 +436,7 @@ namespace ClassicAssist.UI.ViewModels
                 if ( string.IsNullOrEmpty( FilterText ) )
                 {
                     FilterDraggables = Draggables;
+                    return;
                 }
 
                 if ( IsSearching )

--- a/ClassicAssist/UI/ViewModels/SkillsTabViewModel.cs
+++ b/ClassicAssist/UI/ViewModels/SkillsTabViewModel.cs
@@ -211,6 +211,11 @@ namespace ClassicAssist.UI.ViewModels
                     LockStatus = si.LockStatus
                 };
 
+                if ( string.IsNullOrEmpty( skill.Name ) && si.BaseValue == 0 )
+                {
+                    continue;
+                }
+
                 _dispatcher.Invoke( () =>
                 {
                     Items.AddSorted( se, comparer );

--- a/ClassicAssist/UO/Network/IncomingPacketHandlers.cs
+++ b/ClassicAssist/UO/Network/IncomingPacketHandlers.cs
@@ -412,6 +412,12 @@ namespace ClassicAssist.UO.Network
 
             int id = ( packet[7] << 8 ) | packet[8];
 
+            if ((id & 0x4000) != 0)
+            {
+                id ^= 0x4000;
+                item.ArtDataID = 2;
+            }
+
             if ( ( id & 0x8000 ) != 0 )
             {
                 id ^= 0x8000;


### PR DESCRIPTION
Skills with no name and 0 base value won't display (custom shards)
Old world item packet will properly set that item is a multi
New macro commands Distance(x, y) and SkillDelta('skillName')