### PR TITLE
#233 Fixes/Improves in UseObject, UseType, SkipQueue and UseObjectQueue

### DIFF
--- a/ClassicAssist/Data/Macros/Commands/ActionCommands.cs
+++ b/ClassicAssist/Data/Macros/Commands/ActionCommands.cs
@@ -88,7 +88,7 @@ namespace ClassicAssist.Data.Macros.Commands
 
             UseOnceList.Add( match );
 
-            ObjectCommands.UseObject( match.Serial );
+            ObjectCommands.UseObject( match.Serial, true );
 
             return true;
         }
@@ -190,7 +190,7 @@ namespace ClassicAssist.Data.Macros.Commands
 
             if ( player.IsMounted )
             {
-                ObjectCommands.UseObject( player.Serial );
+                ObjectCommands.UseObject( player.Serial, true );
                 return;
             }
 
@@ -209,7 +209,7 @@ namespace ClassicAssist.Data.Macros.Commands
 
             int mountSerial = AliasCommands.GetAlias( "mount" );
 
-            ObjectCommands.UseObject( mountSerial );
+            ObjectCommands.UseObject( mountSerial, true );
         }
 
         [CommandsDisplay( Category = nameof( Strings.Actions ),

--- a/ClassicAssist/Data/Macros/Commands/ConsumeCommands.cs
+++ b/ClassicAssist/Data/Macros/Commands/ConsumeCommands.cs
@@ -40,7 +40,7 @@ namespace ClassicAssist.Data.Macros.Commands
                 return false;
             }
 
-            ObjectCommands.UseObject( bandage.Serial );
+            ObjectCommands.UseObject( bandage.Serial, true );
 
             PacketWaitEntry we = Engine.PacketWaitEntries.Add( new PacketFilterInfo( 0x6C ), PacketDirection.Incoming );
 


### PR DESCRIPTION
- [x] **Changed UseObject: UseObject is gonna work with ObjectQueue.**  
I.E: Only Usetype was working with ObjectQueue.

- [x] **Fixed integration by SkipQueue params and UseObjectQueue: Now useobjectqueue and skipqueue are gonna work together and independents.**
I.E: If u send SkipQueue params TRUE  from script and u've already setted UseObjectQueue, assistant will ignore UseObjectQueue. It's working like "!" from steam ( !useobject "serial" )
I.E: If user disables UseObjectQueue, hotkey consumes and others wont use ObjectQueue too. User will be able to pick what he wants and how hotkey should be work based on UseObjectQueue checkbox.