### PR TITLE
#215 Added CASystemMessageToJournal, improved journal commands, refactored SystemMessageHues

### DIFF
--- a/ClassicAssist/Data/Abilities/AbilitiesManager.cs
+++ b/ClassicAssist/Data/Abilities/AbilitiesManager.cs
@@ -296,7 +296,7 @@ namespace ClassicAssist.Data.Abilities
 
             if ( _checkHandsInProgress )
             {
-                UOC.SystemMessage( Strings.Arm___Disarm_already_in_progress___, (int) UOC.SystemMessageHues.Red );
+                UOC.SystemMessage( Strings.Arm___Disarm_already_in_progress___, (int) SystemMessageHues.Red );
                 return false;
             }
 

--- a/ClassicAssist/Data/Dress/DressManager.cs
+++ b/ClassicAssist/Data/Dress/DressManager.cs
@@ -159,7 +159,7 @@ namespace ClassicAssist.Data.Dress
                 if ( IsDressing )
                 {
                     UO.Commands.SystemMessage( Strings.Dress_already_in_progress___,
-                        (int) UO.Commands.SystemMessageHues.Red );
+                        (int) SystemMessageHues.Red );
                     return;
                 }
 

--- a/ClassicAssist/Data/Macros/Commands/AbilitiesCommands.cs
+++ b/ClassicAssist/Data/Macros/Commands/AbilitiesCommands.cs
@@ -75,7 +75,7 @@ namespace ClassicAssist.Data.Macros.Commands
                     {
                         if ( primary && manager.IsPrimaryEnabled || !primary && manager.IsSecondaryEnabled )
                         {
-                            UOC.SystemMessage( Strings.Ability_already_set___, (int) UOC.SystemMessageHues.Green,
+                            UOC.SystemMessage( Strings.Ability_already_set___, (int) SystemMessageHues.Green,
                                 true );
 
                             return;
@@ -87,7 +87,7 @@ namespace ClassicAssist.Data.Macros.Commands
                     {
                         if ( primary && !manager.IsPrimaryEnabled || !primary && !manager.IsSecondaryEnabled )
                         {
-                            UOC.SystemMessage( Strings.Ability_not_set___, (int) UOC.SystemMessageHues.Green, true );
+                            UOC.SystemMessage( Strings.Ability_not_set___, (int) SystemMessageHues.Green, true );
 
                             return;
                         }
@@ -105,7 +105,7 @@ namespace ClassicAssist.Data.Macros.Commands
             else
             {
                 UOC.SystemMessage( string.Format( Strings.Setting_ability___0_____, ability ),
-                    (int) UOC.SystemMessageHues.Green );
+                    (int) SystemMessageHues.Green );
                 manager.SetAbility( primary ? AbilityType.Primary : AbilityType.Secondary );
             }
         }

--- a/ClassicAssist/Data/Macros/Commands/ActionCommands.cs
+++ b/ClassicAssist/Data/Macros/Commands/ActionCommands.cs
@@ -578,7 +578,7 @@ namespace ClassicAssist.Data.Macros.Commands
 
                     if ( entry == null )
                     {
-                        UOC.SystemMessage( Strings.Context_menu_entry_not_found___, (int) UOC.SystemMessageHues.Yellow,
+                        UOC.SystemMessage( Strings.Context_menu_entry_not_found___, (int) SystemMessageHues.Yellow,
                             true, true );
                         are.Set();
                         return;
@@ -586,7 +586,7 @@ namespace ClassicAssist.Data.Macros.Commands
 
                     if ( entry.Flags.HasFlag( ContextMenuFlags.Disabled ) )
                     {
-                        UOC.SystemMessage( Strings.Context_menu_entry_disabled, (int) UOC.SystemMessageHues.Yellow,
+                        UOC.SystemMessage( Strings.Context_menu_entry_disabled, (int) SystemMessageHues.Yellow,
                             true, true );
                         are.Set();
                         return;

--- a/ClassicAssist/Data/Macros/Commands/AgentCommands.cs
+++ b/ClassicAssist/Data/Macros/Commands/AgentCommands.cs
@@ -5,6 +5,7 @@ using ClassicAssist.Data.Dress;
 using ClassicAssist.Data.Organizer;
 using ClassicAssist.Data.Vendors;
 using ClassicAssist.Shared.Resources;
+using ClassicAssist.UO.Data;
 using UOC = ClassicAssist.UO.Commands;
 
 namespace ClassicAssist.Data.Macros.Commands
@@ -19,7 +20,7 @@ namespace ClassicAssist.Data.Macros.Commands
 
             if ( manager.IsDressing )
             {
-                UOC.SystemMessage( Strings.Dress_already_in_progress___, (int) UOC.SystemMessageHues.Red );
+                UOC.SystemMessage( Strings.Dress_already_in_progress___, (int) SystemMessageHues.Red );
                 return;
             }
 
@@ -154,7 +155,7 @@ namespace ClassicAssist.Data.Macros.Commands
 
             if ( entry == null )
             {
-                UOC.SystemMessage( Strings.Invalid_VendorBuy_list_name___, (int) UOC.SystemMessageHues.Red );
+                UOC.SystemMessage( Strings.Invalid_VendorBuy_list_name___, (int) SystemMessageHues.Red );
                 return;
             }
 

--- a/ClassicAssist/Data/Macros/Commands/GumpCommands.cs
+++ b/ClassicAssist/Data/Macros/Commands/GumpCommands.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Assistant;
 using ClassicAssist.Shared.Resources;
+using ClassicAssist.UO.Data;
 using ClassicAssist.UO.Gumps;
 using ClassicAssist.UO.Network.Packets;
 using ClassicAssist.UO.Objects.Gumps;
@@ -114,7 +115,7 @@ namespace ClassicAssist.Data.Macros.Commands
                 return SelectionPromptGump.SelectionPrompt( enumerable, message, closable );
             }
 
-            UOC.SystemMessage( Strings.Atleast_one_option_must_be_provided___, (int) UOC.SystemMessageHues.Red );
+            UOC.SystemMessage( Strings.Atleast_one_option_must_be_provided___, (int) SystemMessageHues.Red );
             return ( false, 0 );
         }
 

--- a/ClassicAssist/Data/Macros/Commands/JournalCommands.cs
+++ b/ClassicAssist/Data/Macros/Commands/JournalCommands.cs
@@ -12,7 +12,11 @@ namespace ClassicAssist.Data.Macros.Commands
 {
     public static class JournalCommands
     {
-        [CommandsDisplay( Category = nameof( Strings.Journal ) )]
+        [CommandsDisplay( Category = nameof( Strings.Journal ),
+            Parameters = new[]
+            {
+                nameof( ParameterType.String ), nameof( ParameterType.String ), nameof( ParameterType.Hue ), nameof( ParameterType.Timeout )
+            } )]
         public static bool InJournal( string text, string author = "", int hue = -1, int timeout = -1 )
         {
             bool match;
@@ -55,7 +59,11 @@ namespace ClassicAssist.Data.Macros.Commands
             Engine.Journal.Clear();
         }
 
-        [CommandsDisplay( Category = nameof( Strings.Journal ) )]
+        [CommandsDisplay( Category = nameof( Strings.Journal ),
+            Parameters = new[]
+            {
+                nameof( ParameterType.String ), nameof( ParameterType.Timeout ), nameof( ParameterType.String ), nameof( ParameterType.Hue )
+            } )]
         public static bool WaitForJournal( string text, int timeout, string author = "", int hue = -1 )
         {
             AutoResetEvent are = new AutoResetEvent( false );
@@ -111,7 +119,11 @@ namespace ClassicAssist.Data.Macros.Commands
         }
 
         // ReSharper disable once ExplicitCallerInfoArgument
-        [CommandsDisplay( "WaitForJournalArray", Category = nameof( Strings.Journal ) )]
+        [CommandsDisplay( "WaitForJournalArray", Category = nameof( Strings.Journal ),
+            Parameters = new[]
+            {
+                nameof( ParameterType.StringArray ), nameof( ParameterType.Timeout ), nameof( ParameterType.String )
+            } )]
         public static (int?, string) WaitForJournal( IEnumerable<string> entries, int timeout, string author = "" )
         {
             int? index = null;

--- a/ClassicAssist/Data/Macros/Commands/MacroCommands.cs
+++ b/ClassicAssist/Data/Macros/Commands/MacroCommands.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
 using ClassicAssist.Shared.Resources;
+using ClassicAssist.UO.Data;
 using UOC = ClassicAssist.UO.Commands;
 
 namespace ClassicAssist.Data.Macros.Commands
@@ -67,7 +68,7 @@ namespace ClassicAssist.Data.Macros.Commands
                 return macro.IsRunning;
             }
 
-            UOC.SystemMessage( Strings.Unknown_macro___, (int) UOC.SystemMessageHues.Normal, true );
+            UOC.SystemMessage( Strings.Unknown_macro___, (int) SystemMessageHues.Normal, true );
             return false;
         }
     }

--- a/ClassicAssist/Data/Macros/Commands/MainCommands.cs
+++ b/ClassicAssist/Data/Macros/Commands/MainCommands.cs
@@ -315,7 +315,7 @@ namespace ClassicAssist.Data.Macros.Commands
             }
             catch ( Exception e )
             {
-                UOC.SystemMessage( e.Message, (int) UOC.SystemMessageHues.Red );
+                UOC.SystemMessage( e.Message, (int) SystemMessageHues.Red );
                 return false;
             }
         }

--- a/ClassicAssist/Data/Macros/Commands/MovementCommands.cs
+++ b/ClassicAssist/Data/Macros/Commands/MovementCommands.cs
@@ -113,7 +113,7 @@ namespace ClassicAssist.Data.Macros.Commands
             {
                 if ( gameScene._followingMode )
                 {
-                    UOC.SystemMessage( Strings.Deactivated_following, UOC.SystemMessageHues.Normal, true );
+                    UOC.SystemMessage( Strings.Deactivated_following, SystemMessageHues.Normal, true );
                 }
 
                 gameScene._followingMode = false;
@@ -122,7 +122,7 @@ namespace ClassicAssist.Data.Macros.Commands
             {
                 gameScene._followingMode = true;
                 gameScene._followingTarget = (uint) serial;
-                UOC.SystemMessage( Strings.Activated_following, UOC.SystemMessageHues.Normal, true );
+                UOC.SystemMessage( Strings.Activated_following, SystemMessageHues.Normal, true );
             }
         }
 

--- a/ClassicAssist/UI/ViewModels/Agents/AutolootViewModel.cs
+++ b/ClassicAssist/UI/ViewModels/Agents/AutolootViewModel.cs
@@ -659,7 +659,7 @@ namespace ClassicAssist.UI.ViewModels.Agents
                         }
 
                         UOC.SystemMessage( string.Format( Strings.Autolooting___0__, lootItem.Name ),
-                            (int) UOC.SystemMessageHues.Yellow );
+                            (int) SystemMessageHues.Yellow );
 
                         Task t = ActionPacketQueue.EnqueueDragDrop( lootItem.Serial, lootItem.Count, containerSerial,
                             QueuePriority.High, true, true, requeueOnFailure: RequeueFailedItems,

--- a/ClassicAssist/UO/Commands.cs
+++ b/ClassicAssist/UO/Commands.cs
@@ -27,13 +27,6 @@ namespace ClassicAssist.UO
 {
     public class Commands
     {
-        public enum SystemMessageHues
-        {
-            Normal = 0x3b2,
-            Red = 35,
-            Yellow = 61,
-            Green = 63
-        }
 
         private static readonly object _dragDropLock = new object();
         private static string _lastSystemMessage;
@@ -200,6 +193,8 @@ namespace ClassicAssist.UO
             pw.WriteAsciiFixed( Strings.UO_LOCALE, 4 );
             pw.WriteAsciiFixed( "System\0", 30 );
             pw.Write( textBytes, 0, textBytes.Length );
+
+            IncomingPacketHandlers.CAASystemMessageToJournal( text );
 
             Engine.SendPacketToClient( pw );
         }

--- a/ClassicAssist/UO/Data/Enums.cs
+++ b/ClassicAssist/UO/Data/Enums.cs
@@ -157,4 +157,13 @@ namespace ClassicAssist.UO.Data
         NewMovementSystem = 0x4000,
         NewFeluccaAreas = 0x8000
     }
+
+    [Flags]
+    public enum SystemMessageHues
+    {
+        Normal = 0x3b2,
+        Red = 35,
+        Yellow = 61,
+        Green = 63
+    }
 }

--- a/ClassicAssist/UO/Data/Enums.cs
+++ b/ClassicAssist/UO/Data/Enums.cs
@@ -157,8 +157,7 @@ namespace ClassicAssist.UO.Data
         NewMovementSystem = 0x4000,
         NewFeluccaAreas = 0x8000
     }
-
-    [Flags]
+    
     public enum SystemMessageHues
     {
         Normal = 0x3b2,

--- a/ClassicAssist/UO/Network/ActionPacketQueue.cs
+++ b/ClassicAssist/UO/Network/ActionPacketQueue.cs
@@ -26,6 +26,7 @@ using Assistant;
 using ClassicAssist.Data;
 using ClassicAssist.Misc;
 using ClassicAssist.Shared.Resources;
+using ClassicAssist.UO.Data;
 using ClassicAssist.UO.Network.Packets;
 using ClassicAssist.UO.Objects;
 
@@ -318,7 +319,7 @@ namespace ClassicAssist.UO.Network
                 return true;
             }
 
-            Commands.SystemMessage( Strings.Object_queue_full, (int) Commands.SystemMessageHues.Yellow );
+            Commands.SystemMessage( Strings.Object_queue_full, (int) SystemMessageHues.Yellow );
 
             return false;
         }

--- a/ClassicAssist/UO/Network/IncomingPacketHandlers.cs
+++ b/ClassicAssist/UO/Network/IncomingPacketHandlers.cs
@@ -667,7 +667,7 @@ namespace ClassicAssist.UO.Network
 
             if ( manager.Enabled != AbilityType.None )
             {
-                Commands.SystemMessage( Strings.Current_Ability_Cleared, (int) Commands.SystemMessageHues.Red );
+                Commands.SystemMessage( Strings.Current_Ability_Cleared, (int) SystemMessageHues.Red );
             }
 
             manager.Enabled = AbilityType.None;
@@ -1944,6 +1944,22 @@ namespace ClassicAssist.UO.Network
         {
             Engine.Journal.Write( entry );
             JournalEntryAddedEvent?.Invoke( entry );
+        }
+
+        public static void CAASystemMessageToJournal( string text )
+        {
+            JournalEntry journalEntry = new JournalEntry
+            {
+                Serial = -1,
+                ID = -1,
+                SpeechType = JournalSpeech.System,
+                SpeechHue = (int)SystemMessageHues.Normal,
+                SpeechFont = 0x03,
+                Name = "System",
+                Text = text
+            };
+
+            AddToJournal( journalEntry );
         }
     }
 }


### PR DESCRIPTION
- [x] Added CASystemMessageToJournal
Now, CA SystemMessage will add in JournalEntry, so user will be able to look for text using InJournal that he wrote in SystemMessage or CA sent. 
I.E:
```
ClearJournal()
Pathfind( 647,2073,0 )
Pause(1000)
print InJournal("maximum")
print InJournal("distance","System")
print InJournal("distance","System",-1,1000)
```


- [x] Improved journal commands
Now, InJournal and WaitForJournal can use "alias" as author's param. InJournal has timeout as last param and that can be setted by user.

I.E:
```
SetAlias("beetle", 0x17ea42) #Pet Name = "a war horse"
ClearJournal()
Feed("beetle", 0x9d0,1, -1)
print InJournal("shies", "")
print InJournal("shies")
print InJournal("shies", "a war horse")
print InJournal("shies", "beetle")
print InJournal("shies", "beetle", -1, 300)
```

- [x] Refactored SystemMessageHues
I've put this on Enums.cs to sort...
