### PR TITLE
#237 Changed target distance nearest to work as steam

### DIFF
--- a/ClassicAssist/Data/Targeting/TargetManager.cs
+++ b/ClassicAssist/Data/Targeting/TargetManager.cs
@@ -231,8 +231,7 @@ namespace ClassicAssist.Data.Targeting
 
                 if ( previousMobile != null )
                 {
-                    mobiles = mobiles.Where( m => m.Serial != previousMobile.Serial ).OrderBy( m =>
-                        Math.Max( Math.Abs( m.X - previousMobile.X ), Math.Abs( m.Y - previousMobile.Y ) ) ).ToArray();
+                    mobiles = mobiles.Where( m => m.Serial != previousMobile.Serial && m.Serial != Engine.Player?.Serial ).OrderBy( m => m.Distance ).ToArray();
 
                     if ( mobiles.Length == 0 )
                     {


### PR DESCRIPTION
- [x] Changed GetEnemy and GetFriend to take two closest target when Target.Distance is equals "nearest"
I.E 
```
GetEnemy(['Murderer','Enemy','Innocent','Criminal','Gray'], 'Both', 'Nearest')
```