### PR TITLE
Added Delays, Added Shield Check

### DIFF
--- a/ClassicAssist/Data/Dress/DressAgentEntry.cs
+++ b/ClassicAssist/Data/Dress/DressAgentEntry.cs
@@ -122,8 +122,7 @@ namespace ClassicAssist.Data.Dress
                         }
 
                         ( int otherHand, Layer _ ) = GetConflictingHand( dai.Layer );
-
-                        if ( otherHand != 0 && moveConflicting )
+                        if ( otherHand != 0 && moveConflicting && !item.Name.Contains( "Shield" ))
                         {
                             await ActionPacketQueue.EnqueueDragDrop( otherHand, 1, container, QueuePriority.Medium );
                         }
@@ -152,9 +151,11 @@ namespace ClassicAssist.Data.Dress
                         {
                             case DressAgentItemType.Serial:
                                 await UOC.EquipItem( item, dai.Layer );
+                                Thread.Sleep( 700 );
                                 break;
                             case DressAgentItemType.ID:
                                 await UOC.EquipType( dai.ID, dai.Layer );
+                                Thread.Sleep( 700 );
                                 break;
                             default:
                                 throw new ArgumentOutOfRangeException();

--- a/ClassicAssist/Data/Options.cs
+++ b/ClassicAssist/Data/Options.cs
@@ -26,8 +26,8 @@ namespace ClassicAssist.Data
         private bool _abilitiesGump = true;
         private int _abilitiesGumpX = 100;
         private int _abilitiesGumpY = 100;
-        private bool _actionDelay;
-        private int _actionDelayMs;
+        private bool _actionDelay =  true;
+        private int _actionDelayMs = 500;
         private bool _alwaysOnTop;
         private bool _autoAcceptPartyInvite;
         private bool _autoAcceptPartyOnlyFromFriends;

--- a/ClassicAssist/UO/Network/ActionPacketQueue.cs
+++ b/ClassicAssist/UO/Network/ActionPacketQueue.cs
@@ -45,7 +45,7 @@ namespace ClassicAssist.UO.Network
         public delegate void dActionQueueEvent( ActionQueueEvents actionEvent, BaseQueueItem queueItem );
 
         private const int DRAG_DROP_DISTANCE = 3;
-        private const int DROP_DELAY = 50;
+        private const int DROP_DELAY = 700;
         private const int MAX_ATTEMPTS = 5;
 
         private static readonly ThreadPriorityQueue<BaseQueueItem> _actionPacketQueue =


### PR DESCRIPTION
Added necessary delays so DressAgent (and others) don't trigger wait warnings, and added a check to dressAgent to check if item name contains "shield" so it doesn't unequip it when equipping 1h+shield sets.