### PR TITLE
Fix issue #493: Cliloc buffer overflow protection

### DIFF
--- a/ClassicAssist/UO/Data/Cliloc.cs
+++ b/ClassicAssist/UO/Data/Cliloc.cs
@@ -74,7 +74,11 @@ namespace ClassicAssist.UO.Data
             {
                 len = BitConverter.ToUInt16( fileBytes, x + 5 );
                 int cliloc = BitConverter.ToInt32( fileBytes, x );
-                string value = Encoding.UTF8.GetString( fileBytes, x + 7, len );
+
+                //buffer overflow protection
+                int readLen = fileBytes.Length < x + 7 + len ? fileBytes.Length - ( x + 7 ) : len;
+
+                string value = Encoding.UTF8.GetString( fileBytes, x + 7, readLen );
 
                 if ( !clilocList.ContainsKey( cliloc ) )
                 {


### PR DESCRIPTION
buffer overflow issue related to https://github.com/Reetus/ClassicAssist/pull/455

An overflow error occurs when executing the Encoding.UTF8.GetString statement.

The problematic code:
string value = Encoding.UTF8.GetString(fileBytes, x + 7, len);

Modifying the code as below fixes the bug:
//buffer overflow protection
int readLen = fileBytes.Length < x + 7 + len ? fileBytes.Length - (x + 7) : len;
string value = Encoding.UTF8.GetString(fileBytes, x + 7, readLen);

This modification resolves the overflow error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved data processing safeguards to enhance system stability and prevent potential memory issues during operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->