### PR TITLE
use correct framework

### DIFF
--- a/Tools/SyncPOEditor/SyncPOEditor.csproj
+++ b/Tools/SyncPOEditor/SyncPOEditor.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net90-windows</TargetFramework>
+        <TargetFramework>net9.0-windows</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <OutputPath>..\..\Output</OutputPath>


### PR DESCRIPTION
netcoreapp was [replaced](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks) with net since v5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal project configuration to use the correct framework version. No visible changes to the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->