### PR TITLE
Combine stacks check name if properties enabled minus the argument ma…

### DIFF
--- a/ClassicAssist/UI/ViewModels/EntityCollectionViewerViewModel.cs
+++ b/ClassicAssist/UI/ViewModels/EntityCollectionViewerViewModel.cs
@@ -540,6 +540,16 @@ namespace ClassicAssist.UI.ViewModels
             string sourceStackName = GetNameMinusAmount( item );
             string destStackName = GetNameMinusAmount( destStack );
 
+            if ( item.Count > 1 && sourceStackName.EndsWith( "s" ) && destStack.Count == 1 && !destStackName.EndsWith( "s" ) )
+            {
+                sourceStackName = sourceStackName.TrimEnd( 's' );
+            }
+
+            if ( destStack.Count > 1 && destStackName.EndsWith( "s" ) && item.Count == 1 && !sourceStackName.EndsWith( "s" ) )
+            {
+                destStackName = destStackName.TrimEnd( 's' );
+            }
+
             return sourceStackName.Equals( destStackName );
         }
 

--- a/ClassicAssist/UI/ViewModels/EntityCollectionViewerViewModel.cs
+++ b/ClassicAssist/UI/ViewModels/EntityCollectionViewerViewModel.cs
@@ -491,8 +491,10 @@ namespace ClassicAssist.UI.ViewModels
 
                         int needed = 60000 - destStack.Count;
 
-                        Item sourceStack = Collection.SelectEntities( i => i.ID == destStack.ID && i.Hue == destStack.Hue && i.Serial != destStack.Serial && i.Count != 60000 )
-                            ?.OrderBy( i => i.Count ).FirstOrDefault();
+                        Item sourceStack = Collection
+                            .SelectEntities( i =>
+                                i.ID == destStack.ID && i.Hue == destStack.Hue && i.Serial != destStack.Serial && i.Count != 60000 &&
+                                ( !Engine.TooltipsEnabled || StackNamesMatch( i, destStack ) ) )?.OrderBy( i => i.Count ).FirstOrDefault();
 
                         if ( sourceStack == null )
                         {
@@ -531,6 +533,33 @@ namespace ClassicAssist.UI.ViewModels
                 return Options.CombineStacksIgnore.Any( e =>
                     ( e.ID == -1 || e.ID == item.ID ) && ( e.Hue == -1 || e.Hue == item.Hue ) && ( e.Cliloc == -1 || e.Cliloc == item.Properties?[0].Cliloc ) );
             }
+        }
+
+        private static bool StackNamesMatch( Item item, Item destStack )
+        {
+            string sourceStackName = GetNameMinusAmount( item );
+            string destStackName = GetNameMinusAmount( destStack );
+
+            return sourceStackName.Equals( destStackName );
+        }
+
+        private static string GetNameMinusAmount( Item item )
+        {
+            if ( item.Properties == null || item.Properties.Length == 0 )
+            {
+                return item.Name.Trim();
+            }
+
+            Property property = item.Properties.First();
+
+            if ( property.Arguments == null || property.Arguments.Length == 0 )
+            {
+                return item.Name.Trim();
+            }
+
+            List<string> newArguments = ( from argument in property.Arguments select argument.Equals( item.Count.ToString() ) ? string.Empty : argument ).ToList();
+
+            return newArguments.Count == 0 ? item.Name.Trim() : Cliloc.GetLocalString( property.Cliloc, newArguments.ToArray() ).Trim();
         }
 
         private void TargetContainer( object obj )


### PR DESCRIPTION
…tching the stack amount

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Improved stack combining accuracy when tooltips are enabled by matching item display names, preventing unintended merges of different items that look similar.
  - Better handling of plural forms and localised names during stacking, reducing confusion and accidental item mix-ups.
  - If no suitable source stack is found, the action now safely skips combining and continues, preserving workflow without interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->