### PR TITLE
WaitForTargetOrFizzle to wait for non-Cancel target type / use sender…

### DIFF
--- a/ClassicAssist/Data/Macros/Commands/SpellCommands.cs
+++ b/ClassicAssist/Data/Macros/Commands/SpellCommands.cs
@@ -50,9 +50,11 @@ namespace ClassicAssist.Data.Macros.Commands
             int index = 0;
             bool result;
 
+            int senderSerial = -1;
+
             if ( Options.CurrentOptions.UseExperimentalFizzleDetection )
             {
-                ( index, result ) = UOC.WaitForTargetOrFizzle( sd.Timeout + 1000 );
+                ( index, result ) = UOC.WaitForTargetOrFizzle( sd.Timeout + 1000, out senderSerial );
             }
             else
             {
@@ -80,7 +82,7 @@ namespace ClassicAssist.Data.Macros.Commands
             }
             //
 
-            TargetCommands.Target( serial );
+            TargetCommands.Target( serial, senderSerial: senderSerial );
 
             return true;
         }

--- a/ClassicAssist/Data/Macros/Commands/TargetCommands.cs
+++ b/ClassicAssist/Data/Macros/Commands/TargetCommands.cs
@@ -64,7 +64,7 @@ namespace ClassicAssist.Data.Macros.Commands
 
         [CommandsDisplay( Category = nameof( Strings.Target ),
             Parameters = new[] { nameof( ParameterType.SerialOrAlias ) } )]
-        public static void Target( object obj, bool checkRange = false, bool useQueue = false )
+        public static void Target( object obj, bool checkRange = false, bool useQueue = false, int senderSerial = -1 )
         {
             int serial = AliasCommands.ResolveSerial( obj );
 
@@ -138,7 +138,7 @@ namespace ClassicAssist.Data.Macros.Commands
                 }
             }
 
-            Engine.SendPacketToServer( new Target( TargetTypeEnum.Object, -1, TargetFlags.None, serial, -1, -1, -1, 0,
+            Engine.SendPacketToServer( new Target( TargetTypeEnum.Object, senderSerial, TargetFlags.None, serial, -1, -1, -1, 0,
                 true ) );
             Engine.TargetExists = false;
         }
@@ -608,7 +608,7 @@ namespace ClassicAssist.Data.Macros.Commands
         [CommandsDisplay( Category = nameof( Strings.Target ), Parameters = new[] { nameof( ParameterType.Timeout ) } )]
         public static bool WaitForTargetOrFizzle( int timeout )
         {
-            ( _, bool result ) = UOC.WaitForTargetOrFizzle( timeout );
+            ( _, bool result ) = UOC.WaitForTargetOrFizzle( timeout, out int senderSerial );
 
             return result;
         }

--- a/ClassicAssist/UO/Commands.cs
+++ b/ClassicAssist/UO/Commands.cs
@@ -430,7 +430,10 @@ namespace ClassicAssist.UO
 
         public static PacketWaitEntry[] GetFizzleWaitEntries()
         {
-            PacketWaitEntry targetWe = CreateWaitEntry( new PacketFilterInfo( 0x6C ) );
+            PacketWaitEntry targetWe = CreateWaitEntry( new PacketFilterInfo( 0x6C, new[]
+            {
+                PacketFilterConditions.ByteAtPositionCondition( 3, 6, true )
+            } ) );
 
             PacketWaitEntry fizzWe = CreateWaitEntry( new PacketFilterInfo( 0xC0,
                 new[]
@@ -492,8 +495,10 @@ namespace ClassicAssist.UO
             };
         }
 
-        public static (int, bool) WaitForTargetOrFizzle( int timeout )
+        public static (int, bool) WaitForTargetOrFizzle( int timeout, out int senderSerial )
         {
+            senderSerial = -1;
+
             PacketWaitEntry[] entries = GetFizzleWaitEntries();
 
             Engine.WaitingForTarget = true;
@@ -524,6 +529,12 @@ namespace ClassicAssist.UO
                 catch ( ThreadInterruptedException )
                 {
                     return ( -1, false );
+                }
+
+                if ( index == 0 )
+                {
+                    byte[] packet = entries[0].Packet;
+                    senderSerial = ( packet[2] << 24 ) | ( packet[3] << 16 ) | ( packet[4] << 8 ) | packet[5];
                 }
 
                 return ( index, index == 0 && tasks[0].Result );

--- a/ClassicAssist/UO/Network/PacketFilter/PacketFilterConditions.cs
+++ b/ClassicAssist/UO/Network/PacketFilter/PacketFilterConditions.cs
@@ -2,11 +2,11 @@
 {
     public class PacketFilterConditions
     {
-        public static PacketFilterCondition IntAtPositionCondition( int value, int position )
+        public static PacketFilterCondition IntAtPositionCondition( int value, int position, bool negate = false )
         {
             byte[] valueBytes = { (byte) ( value >> 24 ), (byte) ( value >> 16 ), (byte) ( value >> 8 ), (byte) value };
 
-            return new PacketFilterCondition( position, valueBytes, 4 );
+            return new PacketFilterCondition( position, valueBytes, 4, negate );
         }
 
         public static PacketFilterCondition UIntAtPositionCondition( uint value, int position, bool negate = false )
@@ -16,18 +16,18 @@
             return new PacketFilterCondition( position, valueBytes, 4, negate );
         }
 
-        public static PacketFilterCondition ShortAtPositionCondition( int value, int position )
+        public static PacketFilterCondition ShortAtPositionCondition( int value, int position, bool negate = false )
         {
             byte[] valueBytes = { (byte) ( value >> 8 ), (byte) value };
 
-            return new PacketFilterCondition( position, valueBytes, 2 );
+            return new PacketFilterCondition( position, valueBytes, 2, negate );
         }
 
-        public static PacketFilterCondition ByteAtPositionCondition( int value, int position )
+        public static PacketFilterCondition ByteAtPositionCondition( int value, int position, bool negate = false )
         {
             byte[] valueBytes = { (byte) value };
 
-            return new PacketFilterCondition( position, valueBytes, 1 );
+            return new PacketFilterCondition( position, valueBytes, 1, negate );
         }
     }
 }


### PR DESCRIPTION
… serial from packet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added option to negate packet-filter conditions (int/short/byte at position) for finer inclusion/exclusion rules.
  * Targeting now carries the sender’s serial through the action flow, improving accuracy for macro-driven targeting and fizzle handling.

* **Bug Fixes**
  * Improved fizzle-to-target threading so sender information is preserved across wait/target steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->