### PR TITLE
Adds container set functionality to ECV

### DIFF
--- a/ClassicAssist.Shared/Resources/Strings.Designer.cs
+++ b/ClassicAssist.Shared/Resources/Strings.Designer.cs
@@ -1231,6 +1231,15 @@ namespace ClassicAssist.Shared.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Container Sets.
+        /// </summary>
+        public static string Container_Sets {
+            get {
+                return ResourceManager.GetString("Container Sets", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Context menu entry disabled.
         /// </summary>
         public static string Context_menu_entry_disabled {
@@ -3393,6 +3402,15 @@ namespace ClassicAssist.Shared.Resources {
         public static string Move_to_ground {
             get {
                 return ResourceManager.GetString("Move to ground", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Move to set.
+        /// </summary>
+        public static string Move_to_set {
+            get {
+                return ResourceManager.GetString("Move to set", resourceCulture);
             }
         }
         

--- a/ClassicAssist.Shared/Resources/Strings.en-AU.resx
+++ b/ClassicAssist.Shared/Resources/Strings.en-AU.resx
@@ -2040,7 +2040,7 @@ Are you sure you wish to continue?</value>
   </data>
   <data name="Selected Season:" xml:space="preserve">
     <value>Selected Season:</value>
-  </data>  
+  </data>
   <data name="Check Backpack Item Count" xml:space="preserve">
     <value>Check Backpack Item Count</value>
   </data>
@@ -2052,5 +2052,11 @@ Are you sure you wish to continue?</value>
   </data>
   <data name="Stackable" xml:space="preserve">
     <value>Stackable</value>
-  </data>    
+  </data>
+  <data name="Container Sets" xml:space="preserve">
+    <value>Container Sets</value>
+  </data>
+  <data name="Move to set" xml:space="preserve">
+    <value>Move to set</value>
+  </data>
 </root>

--- a/ClassicAssist.Shared/Resources/Strings.en-GB.resx
+++ b/ClassicAssist.Shared/Resources/Strings.en-GB.resx
@@ -2040,7 +2040,7 @@ Are you sure you wish to continue?</value>
   </data>
   <data name="Selected Season:" xml:space="preserve">
     <value>Selected Season:</value>
-  </data>  
+  </data>
   <data name="Check Backpack Item Count" xml:space="preserve">
     <value>Check Backpack Item Count</value>
   </data>
@@ -2052,5 +2052,11 @@ Are you sure you wish to continue?</value>
   </data>
   <data name="Stackable" xml:space="preserve">
     <value>Stackable</value>
-  </data>    
+  </data>
+  <data name="Container Sets" xml:space="preserve">
+    <value>Container Sets</value>
+  </data>
+  <data name="Move to set" xml:space="preserve">
+    <value>Move to set</value>
+  </data>
 </root>

--- a/ClassicAssist.Shared/Resources/Strings.resx
+++ b/ClassicAssist.Shared/Resources/Strings.resx
@@ -2040,7 +2040,7 @@ Are you sure you wish to continue?</value>
   </data>
   <data name="Selected Season:" xml:space="preserve">
     <value>Selected Season:</value>
-  </data>  
+  </data>
   <data name="Check Backpack Item Count" xml:space="preserve">
     <value>Check Backpack Item Count</value>
   </data>
@@ -2052,5 +2052,11 @@ Are you sure you wish to continue?</value>
   </data>
   <data name="Stackable" xml:space="preserve">
     <value>Stackable</value>
-  </data>    
+  </data>
+  <data name="Container Sets" xml:space="preserve">
+    <value>Container Sets</value>
+  </data>
+  <data name="Move to set" xml:space="preserve">
+    <value>Move to set</value>
+  </data>
 </root>

--- a/ClassicAssist/ClassicAssist.csproj
+++ b/ClassicAssist/ClassicAssist.csproj
@@ -142,6 +142,9 @@
     <Compile Update="UI\Views\Autoloot\ClilocSelectionWindow.xaml.cs">
       <DependentUpon>ClilocSelectionWindow.xaml</DependentUpon>
     </Compile>
+    <Compile Update="UI\Views\ECV\Settings\ContainerSetsSettingsControl.xaml.cs">
+      <DependentUpon>ContainerSetsSettingsControl.xaml</DependentUpon>
+    </Compile>
     <Compile Update="UI\Views\ECV\Settings\Controls\EditTextBlocks\ClilocEditTextBlock.xaml.cs">
       <SubType>Code</SubType>
       <DependentUpon>%(Filename)</DependentUpon>

--- a/ClassicAssist/UI/ViewModels/EntityCollectionViewerViewModel.cs
+++ b/ClassicAssist/UI/ViewModels/EntityCollectionViewerViewModel.cs
@@ -50,6 +50,7 @@ namespace ClassicAssist.UI.ViewModels
         private ICommand _contextMoveToBankCommand;
         private ICommand _contextMoveToContainerCommand;
         private ICommand _contextMoveToGroundCommand;
+        private ICommand _contextMoveToSetCommand;
         private ICommand _contextOpenContainerCommand;
         private ICommand _contextTargetCommand;
         private ICommand _contextUseItemCommand;
@@ -176,6 +177,8 @@ namespace ClassicAssist.UI.ViewModels
 
         public ICommand ContextMoveToGroundCommand =>
             _contextMoveToGroundCommand ?? ( _contextMoveToGroundCommand = new RelayCommandAsync( ContextMoveToGround, o => SelectedItems != null ) );
+
+        public ICommand ContextMoveToSetCommand => _contextMoveToSetCommand ?? ( _contextMoveToSetCommand = new RelayCommand( ContextMoveToSet, o => SelectedItems != null ) );
 
         public ICommand ContextOpenContainerCommand =>
             _contextOpenContainerCommand ?? ( _contextOpenContainerCommand = new RelayCommand( ContextOpenContainer,
@@ -364,6 +367,117 @@ namespace ClassicAssist.UI.ViewModels
 
                 return true;
             }, string.Format( Strings.Moving_item__0_____1_, 0, items.Length ) );
+        }
+
+        private void ContextMoveToSet( object arg )
+        {
+            List<int> usedContainers = new List<int>();
+
+            if ( !( arg is ObservableCollection<int> containers ) )
+            {
+                return;
+            }
+
+            Item[] items = SelectedItems.Where( i => i.Entity is Item ).Select( i => i.Entity ).Cast<Item>().ToArray();
+
+            EnqueueAction( async obj =>
+            {
+                foreach ( var item in items.Select( ( value, i ) => new { i, value } ) )
+                {
+                    if ( obj.CancellationTokenSource.IsCancellationRequested )
+                    {
+                        _dispatcher.Invoke( () => { obj.Status = Strings.Cancel; } );
+                        return false;
+                    }
+
+                    _dispatcher.Invoke( () => { obj.Status = string.Format( Strings.Moving_item__0_____1_, item.i, items.Length ); } );
+
+                    int attempts;
+
+                    for ( attempts = 0; attempts < 5; attempts++ )
+                    {
+                        int serial = await GetContainer();
+
+                        if ( item.value.Owner == serial )
+                        {
+                            break;
+                        }
+
+                        PacketFilterInfo pfi = new PacketFilterInfo( 0x25, new[] { PacketFilterConditions.IntAtPositionCondition( item.value.Serial, 1 ), PacketFilterConditions.IntAtPositionCondition( serial, 15 ) } );
+                        PacketWaitEntry waitEntry = Engine.PacketWaitEntries.Add( pfi, PacketDirection.Incoming, true );
+
+                        if ( !await EnqueueDragDrop( item.value.Serial, -1, serial, obj.CancellationTokenSource.Token ) )
+                        {
+                            Commands.SystemMessage( $"Retrying 0x{item.value.Serial:x}..." );
+                            continue;
+                        }
+
+                        bool result = waitEntry.Lock.WaitOne( 3000 );
+
+                        if ( !result )
+                        {
+                            Commands.SystemMessage( $"Retrying 0x{item.value.Serial:x}..." );
+                            continue;
+                        }
+
+                        break;
+                    }
+                }
+
+                return true;
+            }, string.Format( Strings.Moving_item__0_____1_, 0, items.Length ) );
+
+            return;
+
+            async Task<int> GetContainer()
+            {
+                if ( !Engine.TooltipsEnabled )
+                {
+                    return containers.FirstOrDefault();
+                }
+
+                int serial = containers.FirstOrDefault();
+
+                foreach ( int container in containers )
+                {
+                    Item item = Engine.Items.GetItem( container );
+
+                    if ( item == null )
+                    {
+                        continue;
+                    }
+
+                    if ( item.Properties == null )
+                    {
+                        await Commands.WaitForPropertiesAsync( new[] { item }, 5000 );
+                    }
+
+                    Property property = item.Properties?.FirstOrDefault( e => e.Cliloc == 1073841 );
+
+                    if ( property == null )
+                    {
+                        continue;
+                    }
+
+                    if ( property.Arguments[0].Equals( property.Arguments[1] ) )
+                    {
+                        continue;
+                    }
+
+                    serial = container;
+
+                    if (!usedContainers.Contains( serial ) )
+                    {
+                        Commands.WaitForContainerContentsUse( serial, 5000 );
+                        await Task.Delay( CurrentOptions.ActionDelayMS );
+                        usedContainers.Add( serial );
+                    }
+
+                    break;
+                }
+
+                return serial;
+            }
         }
 
         public EntityCollectionViewerOptions LoadOptions()
@@ -575,7 +689,7 @@ namespace ClassicAssist.UI.ViewModels
 
             bool Excluded( Entity item )
             {
-                if (Options.CombineStacksIgnore == null || Options.CombineStacksIgnore.Count == 0 )
+                if ( Options.CombineStacksIgnore == null || Options.CombineStacksIgnore.Count == 0 )
                 {
                     return false;
                 }
@@ -1117,7 +1231,7 @@ namespace ClassicAssist.UI.ViewModels
 
                     int attempts;
 
-                    for (attempts = 0; attempts < 5; attempts++ )
+                    for ( attempts = 0; attempts < 5; attempts++ )
                     {
                         if ( !await EnqueueDragDrop( item.value, -1, serial, obj.CancellationTokenSource.Token ) )
                         {
@@ -1133,7 +1247,8 @@ namespace ClassicAssist.UI.ViewModels
             }, string.Format( Strings.Moving_item__0_____1_, 0, items.Length ) );
         }
 
-        private static Task<bool> EnqueueDragDrop( int serial, int amount, int containerSerial, CancellationToken cancellationToken = default, [CallerMemberName] string caller = "" )
+        private static Task<bool> EnqueueDragDrop( int serial, int amount, int containerSerial, CancellationToken cancellationToken = default,
+            [CallerMemberName] string caller = "" )
         {
             ActionQueueItem actionQueueItem = new ActionQueueItem( param =>
             {
@@ -1147,8 +1262,7 @@ namespace ClassicAssist.UI.ViewModels
                     new[]
                     {
                         PacketFilterConditions.ShortAtPositionCondition( 0x57, 2 ), PacketFilterConditions.ShortAtPositionCondition( Engine.Player.X, 6 ),
-                        PacketFilterConditions.ShortAtPositionCondition( Engine.Player.Y, 8 ),
-                        PacketFilterConditions.ShortAtPositionCondition( Engine.Player.Z, 10 )
+                        PacketFilterConditions.ShortAtPositionCondition( Engine.Player.Y, 8 ), PacketFilterConditions.ShortAtPositionCondition( Engine.Player.Z, 10 )
                     } );
 
                 PacketWaitEntry pwe1 = Engine.PacketWaitEntries.Add( pfi1, PacketDirection.Incoming, true );

--- a/ClassicAssist/UI/Views/ECV/ContextMenu.xaml
+++ b/ClassicAssist/UI/Views/ECV/ContextMenu.xaml
@@ -2,8 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:resources="clr-namespace:ClassicAssist.Shared.Resources;assembly=ClassicAssist.Shared"
                     xmlns:viewModels="clr-namespace:ClassicAssist.UI.ViewModels"
-                    xmlns:misc="clr-namespace:ClassicAssist.Misc"
-                    xmlns:system="clr-namespace:System;assembly=mscorlib">
+                    xmlns:misc="clr-namespace:ClassicAssist.Misc">
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary>
             <misc:BindingProxy x:Key="Proxy" Data="{Binding}" />
@@ -18,6 +17,28 @@
                           Command="{Binding Source={StaticResource Proxy}, Path=Data.(viewModels:EntityCollectionViewerViewModel.ContextMoveToBankCommand)}" />
                 <MenuItem Header="{x:Static resources:Strings.Move_to_ground}"
                           Command="{Binding Source={StaticResource Proxy}, Path=Data.(viewModels:EntityCollectionViewerViewModel.ContextMoveToGroundCommand)}" />
+                <MenuItem Header="{x:Static resources:Strings.Move_to_set}"
+                          ItemsSource="{Binding Source={StaticResource Proxy}, Path=Data.(viewModels:EntityCollectionViewerViewModel.Options).ContainerSets}">
+                    <MenuItem.Style>
+                        <Style TargetType="{x:Type MenuItem}" BasedOn="{StaticResource {x:Type MenuItem}}">
+                            <Style.Triggers>
+                                <DataTrigger
+                                    Binding="{Binding Source={StaticResource Proxy}, Path=Data.(viewModels:EntityCollectionViewerViewModel.Options).ContainerSets.Count}"
+                                    Value="0">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </MenuItem.Style>
+                    <MenuItem.ItemContainerStyle>
+                        <Style TargetType="MenuItem">
+                            <Setter Property="Header" Value="{Binding Name}" />
+                            <Setter Property="Command"
+                                    Value="{Binding Source={StaticResource Proxy}, Path=Data.(viewModels:EntityCollectionViewerViewModel.ContextMoveToSetCommand)}" />
+                            <Setter Property="CommandParameter" Value="{Binding Items}" />
+                        </Style>
+                    </MenuItem.ItemContainerStyle>
+                </MenuItem>
                 <MenuItem Header="{x:Static resources:Strings.Open_container}"
                           Command="{Binding Source={StaticResource Proxy}, Path=Data.(viewModels:EntityCollectionViewerViewModel.ContextOpenContainerCommand)}" />
                 <Separator />

--- a/ClassicAssist/UI/Views/ECV/EntityCollectionViewerSettingsWindow.xaml
+++ b/ClassicAssist/UI/Views/ECV/EntityCollectionViewerSettingsWindow.xaml
@@ -28,29 +28,46 @@
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <StackPanel>
-            <GroupBox Header="{x:Static resources:Strings.Combine_stacks}" Margin="10" Padding="10">
-                <settings:CombineStacksSettingsControl
-                    Items="{Binding DataContext.Options.CombineStacksIgnore, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ecv:EntityCollectionViewerSettingsWindow}}}" />
-            </GroupBox>
-            <GroupBox Header="{x:Static resources:Strings.Open_All_Containers}" Margin="10,0,10,10" Padding="10">
-                <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="*" />
-                    </Grid.RowDefinitions>
-                    <CheckBox Grid.Row="0"
-                              IsChecked="{Binding DataContext.Options.OpenContainersOnlyKnownContainers, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ecv:EntityCollectionViewerSettingsWindow}}}"
-                              Content="{x:Static resources:Strings.Only_known_containers}" Margin="0,0,0,5" />
-                    <settings:OpenContainersSettingsControl Grid.Row="1"
-                                                            Items="{Binding DataContext.Options.OpenContainersIgnore, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ecv:EntityCollectionViewerSettingsWindow}}}" />
-                </Grid>
-            </GroupBox>
-            <GroupBox Header="{x:Static resources:Strings.Additional_Assemblies}" Margin="10,0,10,10" Padding="10">
-                <controls:AdditionalAssembliesControl
-                    Items="{Binding DataContext.Options.Assemblies, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ecv:EntityCollectionViewerSettingsWindow}}}" />
-            </GroupBox>
-        </StackPanel>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <StackPanel Grid.Column="0">
+                <GroupBox Header="{x:Static resources:Strings.Combine_stacks}" Margin="10" Padding="10">
+                    <settings:CombineStacksSettingsControl
+                        Items="{Binding DataContext.Options.CombineStacksIgnore, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ecv:EntityCollectionViewerSettingsWindow}}}" />
+                </GroupBox>
+                <GroupBox Header="{x:Static resources:Strings.Open_All_Containers}" Margin="10,0,10,10" Padding="10">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+                        <CheckBox Grid.Row="0"
+                                  IsChecked="{Binding DataContext.Options.OpenContainersOnlyKnownContainers, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ecv:EntityCollectionViewerSettingsWindow}}}"
+                                  Content="{x:Static resources:Strings.Only_known_containers}" Margin="0,0,0,5" />
+                        <settings:OpenContainersSettingsControl Grid.Row="1"
+                                                                Items="{Binding DataContext.Options.OpenContainersIgnore, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ecv:EntityCollectionViewerSettingsWindow}}}" />
+                    </Grid>
+                </GroupBox>
+            </StackPanel>
+            <Grid Grid.Column="1">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+                <GroupBox Header="{x:Static resources:Strings.Container_Sets}" Margin="0,10,10,15" Padding="10">
+                    <settings:ContainerSetsSettingsControl
+                        Items="{Binding DataContext.Options.ContainerSets, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ecv:EntityCollectionViewerSettingsWindow}}}" />
+                </GroupBox>
+                <GroupBox Grid.Row="1" Header="{x:Static resources:Strings.Additional_Assemblies}" Margin="0,0,10,10"
+                          Padding="10">
+                    <controls:AdditionalAssembliesControl
+                        Items="{Binding DataContext.Options.Assemblies, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ecv:EntityCollectionViewerSettingsWindow}}}" />
+                </GroupBox>
+            </Grid>
+        </Grid>
         <StackPanel Grid.Row="1" HorizontalAlignment="Right" Margin="0,0,10,10" Orientation="Horizontal">
             <Button Content="{x:Static resources:Strings.OK}" Margin="0,0,5,0" Command="{Binding OKCommand}">
                 <b:Interaction.Behaviors>

--- a/ClassicAssist/UI/Views/ECV/Icons.xaml
+++ b/ClassicAssist/UI/Views/ECV/Icons.xaml
@@ -218,6 +218,13 @@
                     </DrawingGroup>
                 </DrawingImage.Drawing>
             </DrawingImage>
+            <DrawingImage x:Key="FindIcon">
+                <DrawingImage.Drawing>
+                    <DrawingGroup ClipGeometry="M0,0 V512 H512 V0 H0 Z">
+                        <GeometryDrawing Brush="{DynamicResource ThemeForegroundBrush}" Geometry="F1 M512,512z M0,0z M416,208C416,253.9,401.1,296.3,376,330.7L502.6,457.4C515.1,469.9 515.1,490.2 502.6,502.7 490.1,515.2 469.8,515.2 457.3,502.7L330.7,376C296.3,401.1 253.9,416 208,416 93.1,416 0,322.9 0,208 0,93.1 93.1,0 208,0 322.9,0 416,93.1 416,208z M208,352A144,144,0,1,0,208,64A144,144,0,1,0,208,352z" />
+                    </DrawingGroup>
+                </DrawingImage.Drawing>
+            </DrawingImage>
         </ResourceDictionary>
     </ResourceDictionary.MergedDictionaries>
 </ResourceDictionary>

--- a/ClassicAssist/UI/Views/ECV/Settings/ContainerSetsSettingsControl.xaml
+++ b/ClassicAssist/UI/Views/ECV/Settings/ContainerSetsSettingsControl.xaml
@@ -1,0 +1,106 @@
+﻿<UserControl x:Name="userControl" x:Class="ClassicAssist.UI.Views.ECV.Settings.ContainerSetsSettingsControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:controls="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls"
+             xmlns:valueConverters="clr-namespace:ClassicAssist.Shared.UI.ValueConverters;assembly=ClassicAssist.Shared"
+             xmlns:valueConverters1="clr-namespace:ClassicAssist.UI.Misc.ValueConverters"
+             xmlns:dd="urn:gong-wpf-dragdrop"
+             mc:Ignorable="d">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="../../../../Resources/DarkTheme.xaml" />
+                <ResourceDictionary
+                    Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/DebugToolBarStyle.xaml" />
+                <ResourceDictionary Source="../../ECV/Icons.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+            <valueConverters:CellWidthValueConverter x:Key="CellWidthValueConverter" />
+            <valueConverters1:HexToIntValueConverter x:Key="HexToIntValueConverter" />
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="200" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <Grid Grid.Column="0" DataContext="{Binding ElementName=userControl, Mode=TwoWay, Path=.}">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+                <ToolBar Grid.Row="0" Margin="0,0,0,5">
+                    <ToolBar.Resources>
+                        <Style TargetType="{x:Type controls:ImageButton}"
+                               BasedOn="{StaticResource {x:Type controls:ImageButton}}">
+                            <Setter Property="Margin" Value="0,0,5,0" />
+                        </Style>
+                    </ToolBar.Resources>
+                    <ToolBar.Style>
+                        <StaticResource ResourceKey="ToolBarStyle1" />
+                    </ToolBar.Style>
+                    <controls:ImageButton ImageSource="{StaticResource PlusIcon}" Command="{Binding AddSetCommand}" />
+                    <controls:ImageButton ImageSource="{StaticResource RemoveIcon}"
+                                          Command="{Binding RemoveSetCommand}"
+                                          CommandParameter="{Binding SelectedSet}" />
+                </ToolBar>
+                <ListBox Grid.Row="1" ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedSet}"
+                         dd:DragDrop.IsDragSource="True" dd:DragDrop.IsDropTarget="True">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <controls:EditTextBlock Text="{Binding Name}" ShowIcon="True"
+                                                    Width="{Binding ActualWidth, ConverterParameter=10, Converter={StaticResource CellWidthValueConverter}, Mode=OneWay, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ListBoxItem}}}" />
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+            </Grid>
+        </Grid>
+        <Grid Grid.Column="1" DataContext="{Binding ElementName=userControl, Mode=TwoWay, Path=.}" Margin="10,0,0,0">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+                <ToolBar Grid.Row="0" Margin="0,0,0,5">
+                    <ToolBar.Resources>
+                        <Style TargetType="{x:Type controls:ImageButton}"
+                               BasedOn="{StaticResource {x:Type controls:ImageButton}}">
+                            <Setter Property="Margin" Value="0,0,5,0" />
+                        </Style>
+                    </ToolBar.Resources>
+                    <ToolBar.Style>
+                        <StaticResource ResourceKey="ToolBarStyle1" />
+                    </ToolBar.Style>
+                    <controls:ImageButton ImageSource="{StaticResource CrosshairIcon}"
+                                          Command="{Binding AddItemCommand}" />
+                    <controls:ImageButton ImageSource="{StaticResource RemoveIcon}"
+                                          Command="{Binding RemoveItemCommand}"
+                                          CommandParameter="{Binding SelectedItem}" />
+                    <controls:ImageButton ImageSource="{StaticResource FindIcon}"
+                                          Command="{Binding IdentifyContainersCommand}"
+                                          CommandParameter="{Binding SelectedSet.Items}" />
+                </ToolBar>
+                <ListBox Grid.Row="1" ItemsSource="{Binding SelectedSet.Items}" SelectedItem="{Binding SelectedItem}"
+                         MinHeight="100" dd:DragDrop.IsDragSource="True" dd:DragDrop.IsDropTarget="True">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <controls:EditTextBlock
+                                Text="{Binding Path=., Mode=TwoWay, Converter={StaticResource HexToIntValueConverter}, StringFormat=0x\{0:x8\}}"
+                                ShowIcon="True"
+                                Width="{Binding ActualWidth, ConverterParameter=10, Converter={StaticResource CellWidthValueConverter}, Mode=OneWay, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ListBoxItem}}}">
+                                <controls:EditTextBlock.Buttons>
+                                    <controls:ImageButton ImageSource="{StaticResource FindIcon}" BorderThickness="0"
+                                                          HorizontalAlignment="Right" Padding="0" Margin="2,0,0,0"
+                                                          Command="{Binding IdentifyContainersCommand, ElementName=userControl}"
+                                                          CommandParameter="{Binding Path=.}" />
+                                </controls:EditTextBlock.Buttons>
+                            </controls:EditTextBlock>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+            </Grid>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/ClassicAssist/UI/Views/ECV/Settings/ContainerSetsSettingsControl.xaml.cs
+++ b/ClassicAssist/UI/Views/ECV/Settings/ContainerSetsSettingsControl.xaml.cs
@@ -1,0 +1,167 @@
+﻿#region License
+
+// Copyright (C) 2025 Reetus
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#endregion
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Input;
+using Assistant;
+using ClassicAssist.Shared.UI;
+using ClassicAssist.UI.Views.ECV.Settings.Models;
+using ClassicAssist.UO;
+using ClassicAssist.UO.Network.Packets;
+using ClassicAssist.UO.Objects;
+
+namespace ClassicAssist.UI.Views.ECV.Settings
+{
+    /// <summary>
+    ///     Interaction logic for ContainerSetsSettingControl.xaml
+    /// </summary>
+    public partial class ContainerSetsSettingsControl : INotifyPropertyChanged
+    {
+        public static readonly DependencyProperty ItemsProperty = DependencyProperty.Register( nameof( Items ), typeof( ObservableCollection<ContainerSet> ),
+            typeof( ContainerSetsSettingsControl ), new FrameworkPropertyMetadata( null, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault ) );
+
+        private ICommand _addItemCommand;
+
+        private ICommand _addSetCommand;
+        private ICommand _identifyContainerCommand;
+        private ICommand _identifySetCommand;
+        private ICommand _removeItemCommand;
+        private ICommand _removeSetCommand;
+        private int _selectedItem;
+        private ContainerSet _selectedSet;
+
+        public ContainerSetsSettingsControl()
+        {
+            InitializeComponent();
+        }
+
+        public ICommand AddItemCommand => _addItemCommand ?? ( _addItemCommand = new RelayCommandAsync( AddItem, o => SelectedSet != null && Engine.Connected ) );
+
+        public ICommand AddSetCommand => _addSetCommand ?? ( _addSetCommand = new RelayCommand( AddSet ) );
+
+        public ICommand IdentifyContainersCommand =>
+            _identifyContainerCommand ?? ( _identifyContainerCommand =
+                new RelayCommandAsync( IdentifyContainers, o => ( o is int || o is ObservableCollection<int> ) && Engine.Connected ) );
+
+        public ObservableCollection<ContainerSet> Items
+        {
+            get => (ObservableCollection<ContainerSet>) GetValue( ItemsProperty );
+            set => SetValue( ItemsProperty, value );
+        }
+
+        public ICommand RemoveItemCommand => _removeItemCommand ?? ( _removeItemCommand = new RelayCommand( RemoveItem, o => SelectedSet != null ) );
+
+        public ICommand RemoveSetCommand => _removeSetCommand ?? ( _removeSetCommand = new RelayCommand( RemoveSet, o => SelectedSet != null ) );
+
+        public int SelectedItem
+        {
+            get => _selectedItem;
+            set => SetField( ref _selectedItem, value );
+        }
+
+        public ContainerSet SelectedSet
+        {
+            get => _selectedSet;
+            set => SetField( ref _selectedSet, value );
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private static async Task IdentifyContainers( object arg )
+        {
+            List<int> serials = new List<int>();
+
+            switch ( arg )
+            {
+                case int serial when serial != 0:
+                    serials.Add( serial );
+                    break;
+                case ObservableCollection<int> set:
+                    serials.AddRange( set );
+                    break;
+            }
+
+            if ( serials.Count == 0 )
+            {
+                return;
+            }
+
+            Item[] items = Engine.Items.SelectEntities( e => serials.Contains( e.Serial ) );
+
+            foreach ( Item item in items )
+            {
+                Engine.SendPacketToClient( new SAWorldItem( item, 1919 ) );
+            }
+
+            await Task.Delay( 1000 );
+
+            foreach ( Item item in items )
+            {
+                Engine.SendPacketToClient( new SAWorldItem( item ) );
+            }
+        }
+
+        private void RemoveItem( object obj )
+        {
+            SelectedSet.Items.Remove( SelectedItem );
+        }
+
+        private async Task AddItem( object obj )
+        {
+            int serial = await Commands.GetTargetSerialAsync();
+
+            if ( serial != 0 && serial != -1 && SelectedSet != null )
+            {
+                SelectedSet.Items.Add( serial );
+            }
+        }
+
+        private void RemoveSet( object obj )
+        {
+            Items.Remove( SelectedSet );
+        }
+
+        private void AddSet( object obj )
+        {
+            Items.Add( new ContainerSet { Name = "Set" } );
+        }
+
+        protected virtual void OnPropertyChanged( [CallerMemberName] string propertyName = null )
+        {
+            PropertyChanged?.Invoke( this, new PropertyChangedEventArgs( propertyName ) );
+        }
+
+        protected bool SetField<T>( ref T field, T value, [CallerMemberName] string propertyName = null )
+        {
+            if ( EqualityComparer<T>.Default.Equals( field, value ) )
+            {
+                return false;
+            }
+
+            field = value;
+            OnPropertyChanged( propertyName );
+            return true;
+        }
+    }
+}

--- a/ClassicAssist/UI/Views/ECV/Settings/Models/ContainerSet.cs
+++ b/ClassicAssist/UI/Views/ECV/Settings/Models/ContainerSet.cs
@@ -1,0 +1,38 @@
+﻿#region License
+
+// Copyright (C) $CURRENT_YEAR$ Reetus
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+
+#endregion
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using ClassicAssist.Shared.UI;
+
+namespace ClassicAssist.UI.Views.ECV.Settings.Models
+{
+    public class ContainerSet : SetPropertyNotifyChanged
+    {
+        private ObservableCollection<int> _items = new ObservableCollection<int>();
+        private string _name;
+
+        public ObservableCollection<int> Items
+        {
+            get => _items;
+            set => SetProperty( ref _items, value );
+        }
+
+        public string Name
+        {
+            get => _name;
+            set => SetProperty( ref _name, value );
+        }
+    }
+}

--- a/ClassicAssist/UO/Network/Packets/SAWorldItem.cs
+++ b/ClassicAssist/UO/Network/Packets/SAWorldItem.cs
@@ -19,6 +19,7 @@
 
 using System.IO;
 using ClassicAssist.UO.Data;
+using ClassicAssist.UO.Objects;
 
 namespace ClassicAssist.UO.Network.Packets
 {
@@ -37,6 +38,26 @@ namespace ClassicAssist.UO.Network.Packets
             _writer.Seek( 21, SeekOrigin.Begin );
             _writer.Write( (short) hueOverride );
             _writer.Seek( 0, SeekOrigin.End );
+        }
+
+        public SAWorldItem( Item item, int hueOverride = -1 )
+        {
+            _writer = new PacketWriter( 26 );
+            _writer.Write( (byte) 0xF3 );
+            _writer.Write( (short) 0x01 );
+            _writer.Write( (byte) item.ArtDataID );
+            _writer.Write( item.Serial );
+            _writer.Write( (short) item.ID );
+            _writer.Write( (byte) item.Direction );
+            _writer.Write( (short) item.Count );
+            _writer.Write( (short) item.Count );
+            _writer.Write( (short) item.X );
+            _writer.Write( (short) item.Y );
+            _writer.Write( (sbyte) item.Z );
+            _writer.Write( (byte) item.Light );
+            _writer.Write( (short) ( hueOverride > 0 ? hueOverride : item.Hue ) );
+            _writer.Write( (byte) item.Flags );
+            _writer.Fill();
         }
     }
 }


### PR DESCRIPTION
Introduces container sets to the Entity Collection Viewer (ECV), allowing users to define and manage groups of containers.

Adds UI elements for creating, editing, and deleting container sets. Implements functionality to move selected items to a designated container set. Persists container set configurations to a JSON file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added Container Sets: create, name, and organise sets of target containers with drag-and-drop.
  - New context menu action “Move to set” to move selected items into a chosen set.
  - Identify containers within a set to assist setup.

- UI
  - Settings window reorganised into a two‑column layout with a new Container Sets section.
  - Context menu dynamically shows sets when available.
  - Added new icons for improved clarity.

- Localisation
  - Added “Container Sets” and “Move to set” strings for en‑AU and en‑GB.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->