### PR TITLE
Adds Organizer matching to ECV filters

### DIFF
--- a/ClassicAssist.Shared/Resources/Strings.Designer.cs
+++ b/ClassicAssist.Shared/Resources/Strings.Designer.cs
@@ -3865,6 +3865,15 @@ namespace ClassicAssist.Shared.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Organizer Match.
+        /// </summary>
+        public static string Organizer_Match {
+            get {
+                return ResourceManager.GetString("Organizer Match", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Original.
         /// </summary>
         public static string Original {

--- a/ClassicAssist.Shared/Resources/Strings.en-AU.resx
+++ b/ClassicAssist.Shared/Resources/Strings.en-AU.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -2082,5 +2082,8 @@ Are you sure you wish to continue?</value>
   </data>
   <data name="Open in external editor" xml:space="preserve">
     <value>Open in external editor</value>
+  </data>
+  <data name="Organizer Match" xml:space="preserve">
+    <value>Organizer Match</value>
   </data>
 </root>

--- a/ClassicAssist.Shared/Resources/Strings.en-GB.resx
+++ b/ClassicAssist.Shared/Resources/Strings.en-GB.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -2082,5 +2082,8 @@ Are you sure you wish to continue?</value>
   </data>
   <data name="Open in external editor" xml:space="preserve">
     <value>Open in external editor</value>
+  </data>
+  <data name="Organizer Match" xml:space="preserve">
+    <value>Organizer Match</value>
   </data>
 </root>

--- a/ClassicAssist.Shared/Resources/Strings.resx
+++ b/ClassicAssist.Shared/Resources/Strings.resx
@@ -2086,4 +2086,7 @@ Are you sure you wish to continue?</value>
   <data name="Open in external editor" xml:space="preserve">
     <value>Open in external editor</value>
   </data>
+  <data name="Organizer Match" xml:space="preserve">
+    <value>Organizer Match</value>
+  </data>
 </root>

--- a/ClassicAssist/Data/Autoloot/PropertyEntry.cs
+++ b/ClassicAssist/Data/Autoloot/PropertyEntry.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 // Copyright (C) 2025 Reetus
 // 
@@ -18,6 +18,7 @@
 #endregion
 
 using System;
+using System.Collections.ObjectModel;
 using ClassicAssist.Shared.UI;
 using ClassicAssist.UO.Objects;
 using Newtonsoft.Json;
@@ -32,6 +33,7 @@ namespace ClassicAssist.Data.Autoloot
         private int[] _clilocs;
         private PropertyType _constraintType;
         private string _name;
+        private ObservableCollection<string> _options;
         private Func<Entity, AutolootConstraintEntry, bool> _predicate;
         private string _shortName;
         private bool _useMultipleValues;
@@ -71,6 +73,12 @@ namespace ClassicAssist.Data.Autoloot
         {
             get => _name;
             set => SetProperty( ref _name, value );
+        }
+
+        public ObservableCollection<string> Options
+        {
+            get => _options;
+            set => SetProperty( ref _options, value );
         }
 
         [JsonIgnore]

--- a/ClassicAssist/UI/Views/ECV/Filter/EntityCollectionFilterControl.xaml
+++ b/ClassicAssist/UI/Views/ECV/Filter/EntityCollectionFilterControl.xaml
@@ -18,6 +18,7 @@
     xmlns:views="clr-namespace:ClassicAssist.UI.Views"
     xmlns:behaviours="clr-namespace:ClassicAssist.Controls.Misc.Behaviours;assembly=ClassicAssist.Controls"
     xmlns:behaviours1="clr-namespace:ClassicAssist.UI.Misc.Behaviours"
+    xmlns:valueConverters1="clr-namespace:ClassicAssist.Shared.UI.ValueConverters;assembly=ClassicAssist.Shared"
     x:Name="userControl" x:Class="ClassicAssist.UI.Views.ECV.Filter.EntityCollectionFilterControl"
     mc:Ignorable="d"
     Background="{DynamicResource ThemeBackgroundBrush}">
@@ -31,6 +32,7 @@
             <valueConverters:CellWidthValueConverter x:Key="CellWidthValueConverter" />
             <valueConverters:HexToIntValueConverter x:Key="HexToIntValueConverter" />
             <valueConverters:AutolootOperatorFilterValueConverter x:Key="AutolootOperatorFilterValueConverter" />
+            <valueConverters1:NullToBooleanConverter x:Key="NullToBooleanConverter" />
         </ResourceDictionary>
     </UserControl.Resources>
     <UserControl.DataContext>
@@ -59,12 +61,13 @@
                           SelectedItem="{Binding SelectedProfile}" Style="{StaticResource EditComboBox}">
                     <ComboBox.ItemTemplate>
                         <DataTemplate>
-                            <Grid Width="{Binding ActualWidth, Mode=OneWay, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ComboBox}}}">
+                            <Grid
+                                Width="{Binding ActualWidth, Mode=OneWay, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ComboBox}}}">
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
                                 </Grid.ColumnDefinitions>
-                                <TextBlock Text="{Binding Name}" HorizontalAlignment="Stretch" Grid.Column="0"/>
+                                <TextBlock Text="{Binding Name}" HorizontalAlignment="Stretch" Grid.Column="0" />
                                 <controls:ImageButton ImageSource="{StaticResource ClearIcon}" Grid.Column="1"
                                                       Command="{Binding ElementName=userControl, Path=DataContext.RemoveProfileCommand}"
                                                       CommandParameter="{Binding}">
@@ -77,8 +80,8 @@
                     </ComboBox.ItemTemplate>
                     <i:Interaction.Behaviors>
                         <behaviours1:ComboBoxBehavior CommandBinding="{Binding ChangeProfileCommand}"
-                                                CommandParameter="{Binding SelectedItem, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ComboBox}}}"
-                                                OnlyUserTriggered="True" />
+                                                      CommandParameter="{Binding SelectedItem, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ComboBox}}}"
+                                                      OnlyUserTriggered="True" />
                     </i:Interaction.Behaviors>
                 </ComboBox>
             </StackPanel>
@@ -273,6 +276,25 @@
                                                                 </Style>
                                                             </ComboBox.Style>
                                                         </ComboBox>
+                                                        <ComboBox Grid.Column="0" MinWidth="40"
+                                                                  ItemsSource="{Binding Constraint.Options}"
+                                                                  SelectedItem="{Binding Additional}"
+                                                                  Width="{Binding ActualWidth, Converter={StaticResource CellWidthValueConverter}, ConverterParameter=15, ElementName=GridViewColumn, Mode=OneWay}">
+                                                            <ComboBox.Style>
+                                                                <Style TargetType="{x:Type ComboBox}"
+                                                                       BasedOn="{StaticResource {x:Type ComboBox}}">
+                                                                    <Setter Property="Visibility" Value="Visible" />
+                                                                    <Style.Triggers>
+                                                                        <DataTrigger
+                                                                            Binding="{Binding Constraint.Options}"
+                                                                            Value="{x:Null}">
+                                                                            <Setter Property="Visibility"
+                                                                                    Value="Collapsed" />
+                                                                        </DataTrigger>
+                                                                    </Style.Triggers>
+                                                                </Style>
+                                                            </ComboBox.Style>
+                                                        </ComboBox>
                                                         <TextBox
                                                             Text="{Binding Value, Mode=TwoWay, UpdateSourceTrigger=LostFocus, Converter={StaticResource HexToIntValueConverter}}"
                                                             Width="{Binding ActualWidth, Converter={StaticResource CellWidthValueConverter}, ConverterParameter=15, ElementName=GridViewColumn, Mode=OneWay}"
@@ -315,6 +337,12 @@
                                                                         <DataTrigger
                                                                             Binding="{Binding Constraint.Name}"
                                                                             Value="{x:Static resources:Strings.Autoloot_Match}">
+                                                                            <Setter Property="Visibility"
+                                                                                Value="Collapsed" />
+                                                                        </DataTrigger>
+                                                                        <DataTrigger
+                                                                            Binding="{Binding Constraint.Options, Converter={StaticResource NullToBooleanConverter}}"
+                                                                            Value="True">
                                                                             <Setter Property="Visibility"
                                                                                 Value="Collapsed" />
                                                                         </DataTrigger>

--- a/ClassicAssist/UI/Views/ECV/Filter/EntityCollectionFilterViewModel.cs
+++ b/ClassicAssist/UI/Views/ECV/Filter/EntityCollectionFilterViewModel.cs
@@ -18,6 +18,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
@@ -26,6 +27,7 @@ using System.Windows;
 using System.Windows.Input;
 using Assistant;
 using ClassicAssist.Data.Autoloot;
+using ClassicAssist.Data.Organizer;
 using ClassicAssist.Shared.Misc;
 using ClassicAssist.Shared.Resources;
 using ClassicAssist.Shared.UI;
@@ -116,6 +118,25 @@ namespace ClassicAssist.UI.Views.ECV.Filter
                     }
                 },
                 AllowedValuesEnum = typeof( TileFlags )
+            } );
+
+            Constraints.AddSorted( new PropertyEntry
+            {
+                Name = Strings.Organizer_Match,
+                ConstraintType = PropertyType.PredicateWithValue,
+                AllowedOperators = AutolootAllowedOperators.Equal | AutolootAllowedOperators.NotEqual,
+                Predicate = ( item, entry ) =>
+                {
+                    if ( entry.Additional == null )
+                    {
+                        return false;
+                    }
+
+                    OrganizerEntry organizer = OrganizerManager.GetInstance().Items.FirstOrDefault( e => e.Name == entry.Additional );
+
+                    return organizer != null && organizer.Items.Any( e => e.ID == item.ID && ( e.Hue == -1 || e.Hue == item.Hue ) );
+                },
+                Options = new ObservableCollection<string>( OrganizerManager.GetInstance().Items?.Select( o => o.Name ) ?? new List<string>() )
             } );
 
             manager.LoadAssemblies( Constraints );


### PR DESCRIPTION
Adds a new filter option to the Entity Collection View (ECV) that allows filtering based on items present in specified Organizer profiles. This allows users to easily find items that match their Organizer rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Organizer Match" constraint for entity collection filtering.
  * Enhanced UI to support filtering options with conditional visibility controls.
  * Extended property selection with observable collection support for constraint options.
  * Added localisation support for the new filter constraint across multiple language resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->