### PR TITLE
Fix test isolation to prevent order-dependent failures

### DIFF
--- a/ClassicAssist.Tests/EngineTests.cs
+++ b/ClassicAssist.Tests/EngineTests.cs
@@ -110,7 +110,8 @@ namespace ClassicAssist.Tests
         {
             fixed ( void* func = &_pluginHeader )
             {
-                Engine.Install( (PluginHeader*) func );
+                Engine.Initialize();
+                Engine.InitializePlugin( (PluginHeader*) func );
             }
 
             using ( AutoResetEvent are = new AutoResetEvent( false ) )
@@ -149,7 +150,8 @@ namespace ClassicAssist.Tests
         {
             fixed ( void* func = &_pluginHeader )
             {
-                Engine.Install( (PluginHeader*) func );
+                Engine.Initialize();
+                Engine.InitializePlugin( (PluginHeader*) func );
             }
 
             byte[] packet = { 0x06, 0xAA, 0xBB, 0xCC, 0xDD };
@@ -197,7 +199,8 @@ namespace ClassicAssist.Tests
         {
             fixed ( void* func = &_pluginHeader )
             {
-                Engine.Install( (PluginHeader*) func );
+                Engine.Initialize();
+                Engine.InitializePlugin( (PluginHeader*) func );
             }
 
             byte[] packet = { 0x2F, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88 };
@@ -246,7 +249,8 @@ namespace ClassicAssist.Tests
         {
             fixed ( void* func = &_pluginHeader )
             {
-                Engine.Install( (PluginHeader*) func );
+                Engine.Initialize();
+                Engine.InitializePlugin( (PluginHeader*) func );
             }
 
             byte[] packet = { 0x2F, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88 };

--- a/ClassicAssist.Tests/IncomingPacketHandlerTests.cs
+++ b/ClassicAssist.Tests/IncomingPacketHandlerTests.cs
@@ -20,6 +20,14 @@ namespace ClassicAssist.Tests
             IncomingPacketHandlers.Initialize();
         }
 
+        [TestCleanup]
+        public void Cleanup()
+        {
+            Engine.Player = null;
+            Engine.Items = new ItemCollection( 0 );
+            Engine.Mobiles = new MobileCollection( Engine.Items );
+        }
+
         [TestMethod]
         public void ContainerContentsWillAddToPlayerBackpack()
         {

--- a/ClassicAssist.Tests/MacroCommands/ActionCommandTests.cs
+++ b/ClassicAssist.Tests/MacroCommands/ActionCommandTests.cs
@@ -479,6 +479,10 @@ namespace ClassicAssist.Tests.MacroCommands
         public void Cleanup()
         {
             ActionPacketQueue.Clear();
+            Engine.Player = null;
+            Engine.Items.Clear();
+            Engine.Mobiles.Clear();
+            AliasCommands._aliases.Clear();
         }
     }
 }

--- a/ClassicAssist.Tests/MacroCommands/AliasCommandTests.cs
+++ b/ClassicAssist.Tests/MacroCommands/AliasCommandTests.cs
@@ -19,6 +19,13 @@ namespace ClassicAssist.Tests.MacroCommands
             Engine.Player = _player;
         }
 
+        [TestCleanup]
+        public void Cleanup()
+        {
+            Engine.Player = null;
+            AliasCommands._aliases.Clear();
+        }
+
         [TestMethod]
         public void WillSetDefaultAliases()
         {

--- a/ClassicAssist.Tests/MacroCommands/JournalCommandsTests.cs
+++ b/ClassicAssist.Tests/MacroCommands/JournalCommandsTests.cs
@@ -165,5 +165,11 @@ namespace ClassicAssist.Tests.MacroCommands
 
             //    Engine.Journal.Clear();
             //}
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            Engine.Journal = new CircularBuffer<JournalEntry>( 1024 );
+        }
         }
 }

--- a/ClassicAssist.Tests/MacroCommands/ObjectCommandTests.cs
+++ b/ClassicAssist.Tests/MacroCommands/ObjectCommandTests.cs
@@ -371,6 +371,11 @@ namespace ClassicAssist.Tests.MacroCommands
         public void Cleanup()
         {
             ActionPacketQueue.Clear();
+            Engine.Player = null;
+            Engine.Items.Clear();
+            Engine.Mobiles.Clear();
+            ObjectCommands.ClearIgnoreList();
+            AliasCommands._aliases.Clear();
         }
     }
 }

--- a/ClassicAssist.Tests/MacroCommands/PropertiesCommandTests.cs
+++ b/ClassicAssist.Tests/MacroCommands/PropertiesCommandTests.cs
@@ -117,5 +117,13 @@ namespace ClassicAssist.Tests.MacroCommands
 
             Engine.Items.Clear();
         }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            Engine.Player = null;
+            Engine.Items.Clear();
+            Engine.PacketWaitEntries = null;
+        }
     }
 }

--- a/ClassicAssist.Tests/MacroCommands/PropertiesCommandTests.cs
+++ b/ClassicAssist.Tests/MacroCommands/PropertiesCommandTests.cs
@@ -14,12 +14,14 @@ namespace ClassicAssist.Tests.MacroCommands
     [TestClass]
     public class PropertiesCommandTests
     {
+        private Engine.dSendRecvPacket _internalPacketSentHandler;
+
         [TestMethod]
         public void WillWaitForProperties()
         {
             Engine.PacketWaitEntries = new PacketWaitEntries();
 
-            void OnInternalPacketSentEvent( byte[] data, int length )
+            _internalPacketSentHandler = ( byte[] data, int length ) =>
             {
                 if ( data[0] != 0xD6 )
                 {
@@ -31,16 +33,13 @@ namespace ClassicAssist.Tests.MacroCommands
                 byte[] packet = { 0xD6, 0x00, 0x09, 0x00, 0x01, data[3], data[4], data[5], data[6] };
 
                 Engine.PacketWaitEntries.CheckWait( packet, PacketDirection.Incoming );
-            }
+            };
 
-            Engine.InternalPacketSentEvent += OnInternalPacketSentEvent;
+            Engine.InternalPacketSentEvent += _internalPacketSentHandler;
 
             bool result = PropertiesCommands.WaitForProperties( 0x00aabbcc, 5000 );
 
             Assert.IsTrue( result );
-
-            Engine.PacketWaitEntries = null;
-            Engine.InternalPacketSentEvent -= OnInternalPacketSentEvent;
         }
 
         [TestMethod]
@@ -121,6 +120,12 @@ namespace ClassicAssist.Tests.MacroCommands
         [TestCleanup]
         public void Cleanup()
         {
+            if ( _internalPacketSentHandler != null )
+            {
+                Engine.InternalPacketSentEvent -= _internalPacketSentHandler;
+                _internalPacketSentHandler = null;
+            }
+
             Engine.Player = null;
             Engine.Items.Clear();
             Engine.PacketWaitEntries = null;

--- a/ClassicAssist.Tests/MacroCommands/TargetCommandTests.cs
+++ b/ClassicAssist.Tests/MacroCommands/TargetCommandTests.cs
@@ -1192,5 +1192,18 @@ namespace ClassicAssist.Tests.MacroCommands
                 Engine.PacketWaitEntries = null;
             }
         }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            Engine.Player = null;
+            Engine.Mobiles.Clear();
+            Engine.Items.Clear();
+            Engine.PacketWaitEntries = null;
+            Options.CurrentOptions.GetFriendEnemyUsesIgnoreList = false;
+            Options.CurrentOptions.Friends.Clear();
+            ObjectCommands.ClearIgnoreList();
+            AliasCommands._aliases.Clear();
+        }
     }
 }

--- a/ClassicAssist.Tests/OutgoingPacketHandlerTests.cs
+++ b/ClassicAssist.Tests/OutgoingPacketHandlerTests.cs
@@ -84,6 +84,9 @@ namespace ClassicAssist.Tests
         [TestCleanup]
         public void Cleanup()
         {
+            Engine.Player = null;
+            Engine.Items = new ItemCollection( 0 );
+            Engine.Mobiles = new MobileCollection( Engine.Items );
         }
     }
 }

--- a/ClassicAssist.Tests/SpellCommandsTests.cs
+++ b/ClassicAssist.Tests/SpellCommandsTests.cs
@@ -75,5 +75,13 @@ namespace ClassicAssist.Tests
             Engine.Player = null;
             Engine.PacketWaitEntries = null;
         }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            Engine.Player = null;
+            Engine.PacketWaitEntries = null;
+            Options.CurrentOptions.UseExperimentalFizzleDetection = false;
+        }
     }
 }


### PR DESCRIPTION
Add/enhance [TestCleanup] methods across 10 test classes to properly reset shared static state (Engine.Player, Items, Mobiles, aliases, Options) after each test. Replace Engine.Install() with Initialize() + InitializePlugin() in EngineTests to prevent SplashWindow from appearing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test isolation and cleanup across multiple suites with new centralized teardown hooks to reset shared engine and command state between tests.
  * Standardised initialization flow in affected tests to ensure predictable setup and teardown, reducing flaky tests and improving overall test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->