### PR TITLE
Reduce per-packet allocations in networking hot path

### DIFF
--- a/ClassicAssist.Tests/PacketReaderTests.cs
+++ b/ClassicAssist.Tests/PacketReaderTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+using System.IO;
+using System.Text;
 using ClassicAssist.UO.Data;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -31,6 +32,451 @@ namespace ClassicAssist.Tests
             Assert.AreEqual( 0xAABBCCDD, uint32 );
             Assert.AreEqual( (ushort) 0xEEFF, uint16 );
             Assert.AreEqual( 0x0A, uint8 );
+        }
+
+        [TestMethod]
+        public void ConstructorFixedSizeSkipsOneByte()
+        {
+            byte[] packet = { 0xFF, 0xAA, 0xBB };
+
+            PacketReader reader = new PacketReader( packet, packet.Length, true );
+
+            Assert.AreEqual( 1, reader.Index );
+            Assert.AreEqual( packet.Length, reader.Size );
+            Assert.AreEqual( 0xAA, reader.ReadByte() );
+        }
+
+        [TestMethod]
+        public void ConstructorVariableLengthSkipsThreeBytes()
+        {
+            byte[] packet = { 0xFF, 0x00, 0x05, 0xAA, 0xBB };
+
+            PacketReader reader = new PacketReader( packet, packet.Length, false );
+
+            Assert.AreEqual( 3, reader.Index );
+            Assert.AreEqual( packet.Length, reader.Size );
+            Assert.AreEqual( 0xAA, reader.ReadByte() );
+        }
+
+        [TestMethod]
+        public void ReadByteSingleValue()
+        {
+            byte[] packet = { 0x00, 0x42 };
+            PacketReader reader = new PacketReader( packet, packet.Length, true );
+
+            Assert.AreEqual( 0x42, reader.ReadByte() );
+        }
+
+        [TestMethod]
+        public void ReadBooleanReturnsCorrectValues()
+        {
+            byte[] packet = { 0x00, 0x01, 0x00, 0xFF };
+            PacketReader reader = new PacketReader( packet, packet.Length, true );
+
+            Assert.IsTrue( reader.ReadBoolean() );
+            Assert.IsFalse( reader.ReadBoolean() );
+            Assert.IsTrue( reader.ReadBoolean() );
+        }
+
+        [TestMethod]
+        public void ReadSByteReturnsSignedValue()
+        {
+            byte[] packet = { 0x00, 0x80, 0x7F, 0xFF };
+            PacketReader reader = new PacketReader( packet, packet.Length, true );
+
+            Assert.AreEqual( (sbyte) -128, reader.ReadSByte() );
+            Assert.AreEqual( (sbyte) 127, reader.ReadSByte() );
+            Assert.AreEqual( (sbyte) -1, reader.ReadSByte() );
+        }
+
+        [TestMethod]
+        public void ReadInt16BigEndian()
+        {
+            byte[] packet = { 0x00, 0x00, 0x01, 0x80, 0x00, 0xFF, 0xFF };
+            PacketReader reader = new PacketReader( packet, packet.Length, true );
+
+            Assert.AreEqual( (short) 1, reader.ReadInt16() );
+            Assert.AreEqual( unchecked( (short) 0x8000 ), reader.ReadInt16() );
+            Assert.AreEqual( (short) -1, reader.ReadInt16() );
+        }
+
+        [TestMethod]
+        public void ReadInt32BigEndian()
+        {
+            byte[] packet = { 0x00, 0x00, 0x00, 0x00, 0x01, 0xFF, 0xFF, 0xFF, 0xFF };
+            PacketReader reader = new PacketReader( packet, packet.Length, true );
+
+            Assert.AreEqual( 1, reader.ReadInt32() );
+            Assert.AreEqual( -1, reader.ReadInt32() );
+        }
+
+        [TestMethod]
+        public void ReadUInt16ReturnsUnsigned()
+        {
+            byte[] packet = { 0x00, 0xFF, 0xFF };
+            PacketReader reader = new PacketReader( packet, packet.Length, true );
+
+            Assert.AreEqual( (ushort) 0xFFFF, reader.ReadUInt16() );
+        }
+
+        [TestMethod]
+        public void ReadUInt32ReturnsUnsigned()
+        {
+            byte[] packet = { 0x00, 0xFF, 0xFF, 0xFF, 0xFF };
+            PacketReader reader = new PacketReader( packet, packet.Length, true );
+
+            Assert.AreEqual( 0xFFFFFFFF, reader.ReadUInt32() );
+        }
+
+        [TestMethod]
+        public void ReadByteArrayReturnsCorrectData()
+        {
+            byte[] packet = { 0x00, 0x0A, 0x0B, 0x0C, 0x0D };
+            PacketReader reader = new PacketReader( packet, packet.Length, true );
+
+            byte[] result = reader.ReadByteArray( 3 );
+
+            Assert.AreEqual( 3, result.Length );
+            Assert.AreEqual( 0x0A, result[0] );
+            Assert.AreEqual( 0x0B, result[1] );
+            Assert.AreEqual( 0x0C, result[2] );
+            Assert.AreEqual( 4, reader.Index );
+        }
+
+        [TestMethod]
+        public void ReadStringNullTerminated()
+        {
+            byte[] packet = { 0x00, 0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x00, 0xFF };
+            PacketReader reader = new PacketReader( packet, packet.Length, true );
+
+            string result = reader.ReadString();
+
+            Assert.AreEqual( "Hello", result );
+            Assert.AreEqual( 7, reader.Index );
+        }
+
+        [TestMethod]
+        public void ReadStringFixedLength()
+        {
+            byte[] data = Encoding.ASCII.GetBytes( "Test\0\0\0\0" );
+            byte[] packet = new byte[1 + data.Length];
+            packet[0] = 0x00;
+            System.Array.Copy( data, 0, packet, 1, data.Length );
+
+            PacketReader reader = new PacketReader( packet, packet.Length, true );
+
+            string result = reader.ReadString( 8 );
+
+            Assert.AreEqual( "Test", result );
+        }
+
+        [TestMethod]
+        public void ReadStringFixedLengthFullString()
+        {
+            byte[] packet = { 0x00, 0x41, 0x42, 0x43 };
+            PacketReader reader = new PacketReader( packet, packet.Length, true );
+
+            string result = reader.ReadString( 3 );
+
+            Assert.AreEqual( "ABC", result );
+        }
+
+        [TestMethod]
+        public void ReadStringSafeFixedLength()
+        {
+            byte[] packet = { 0x00, 0x48, 0x69, 0x00, 0xFF, 0xFF };
+            PacketReader reader = new PacketReader( packet, packet.Length, true );
+
+            string result = reader.ReadStringSafe( 5 );
+
+            Assert.AreEqual( "Hi", result );
+            Assert.AreEqual( 6, reader.Index );
+        }
+
+        [TestMethod]
+        public void ReadStringSafeFiltersBadChars()
+        {
+            byte[] packet = { 0x00, 0x41, 0x01, 0x42, 0x00 };
+            PacketReader reader = new PacketReader( packet, packet.Length, true );
+
+            string result = reader.ReadStringSafe( 4 );
+
+            Assert.AreEqual( "AB", result );
+        }
+
+        [TestMethod]
+        public void ReadUnicodeStringNullTerminatedBigEndian()
+        {
+            byte[] packet = { 0x00, 0x00, 0x48, 0x00, 0x69, 0x00, 0x00 };
+            PacketReader reader = new PacketReader( packet, packet.Length, true );
+
+            string result = reader.ReadUnicodeString();
+
+            Assert.AreEqual( "Hi", result );
+        }
+
+        [TestMethod]
+        public void ReadUnicodeStringFixedLengthLittleEndian()
+        {
+            string text = "Test";
+            byte[] encoded = Encoding.Unicode.GetBytes( text );
+            byte[] packet = new byte[1 + encoded.Length];
+            packet[0] = 0x00;
+            System.Array.Copy( encoded, 0, packet, 1, encoded.Length );
+
+            PacketReader reader = new PacketReader( packet, packet.Length, true );
+
+            string result = reader.ReadUnicodeString( encoded.Length );
+
+            Assert.AreEqual( "Test", result );
+        }
+
+        [TestMethod]
+        public void ReadUnicodeStringBEFixedLength()
+        {
+            string text = "AB";
+            byte[] encoded = Encoding.BigEndianUnicode.GetBytes( text );
+            byte[] packet = new byte[1 + encoded.Length];
+            packet[0] = 0x00;
+            System.Array.Copy( encoded, 0, packet, 1, encoded.Length );
+
+            PacketReader reader = new PacketReader( packet, packet.Length, true );
+
+            string result = reader.ReadUnicodeStringBE( 2 );
+
+            Assert.AreEqual( "AB", result );
+        }
+
+        [TestMethod]
+        public void ReadUnicodeStringLENullTerminated()
+        {
+            byte[] packet = { 0x00, 0x48, 0x00, 0x69, 0x00, 0x00, 0x00 };
+            PacketReader reader = new PacketReader( packet, packet.Length, true );
+
+            string result = reader.ReadUnicodeStringLE();
+
+            Assert.AreEqual( "Hi", result );
+        }
+
+        [TestMethod]
+        public void SeekBeginSetsAbsolutePosition()
+        {
+            byte[] packet = { 0x00, 0xAA, 0xBB, 0xCC, 0xDD };
+            PacketReader reader = new PacketReader( packet, packet.Length, true );
+
+            reader.ReadByte();
+            Assert.AreEqual( 2, reader.Index );
+
+            reader.Seek( 1, SeekOrigin.Begin );
+            Assert.AreEqual( 1, reader.Index );
+            Assert.AreEqual( 0xAA, reader.ReadByte() );
+        }
+
+        [TestMethod]
+        public void SeekCurrentAdvancesPosition()
+        {
+            byte[] packet = { 0x00, 0xAA, 0xBB, 0xCC, 0xDD };
+            PacketReader reader = new PacketReader( packet, packet.Length, true );
+
+            reader.Seek( 2, SeekOrigin.Current );
+            Assert.AreEqual( 3, reader.Index );
+            Assert.AreEqual( 0xCC, reader.ReadByte() );
+        }
+
+        [TestMethod]
+        public void SeekEndPositionsFromEnd()
+        {
+            byte[] packet = { 0x00, 0xAA, 0xBB, 0xCC, 0xDD };
+            PacketReader reader = new PacketReader( packet, packet.Length, true );
+
+            reader.Seek( -1, SeekOrigin.End );
+            Assert.AreEqual( 4, reader.Index );
+            Assert.AreEqual( 0xDD, reader.ReadByte() );
+        }
+
+        [TestMethod]
+        public void GetDataReturnsFullPacket()
+        {
+            byte[] packet = { 0x00, 0xAA, 0xBB, 0xCC };
+            PacketReader reader = new PacketReader( packet, packet.Length, true );
+
+            reader.ReadByte();
+
+            byte[] data = reader.GetData();
+
+            Assert.AreEqual( packet.Length, data.Length );
+            Assert.AreEqual( 0x00, data[0] );
+            Assert.AreEqual( 0xAA, data[1] );
+            Assert.AreEqual( 0xBB, data[2] );
+            Assert.AreEqual( 0xCC, data[3] );
+        }
+
+        [TestMethod]
+        public void IndexAndSizeProperties()
+        {
+            byte[] packet = { 0x00, 0x00, 0x06, 0xAA, 0xBB, 0xCC };
+            PacketReader reader = new PacketReader( packet, packet.Length, false );
+
+            Assert.AreEqual( 3, reader.Index );
+            Assert.AreEqual( 6, reader.Size );
+
+            reader.ReadByte();
+
+            Assert.AreEqual( 4, reader.Index );
+            Assert.AreEqual( 6, reader.Size );
+        }
+
+        [TestMethod]
+        public void IsSafeCharValidatesCorrectly()
+        {
+            Assert.IsTrue( PacketReader.IsSafeChar( 0x20 ) );
+            Assert.IsTrue( PacketReader.IsSafeChar( 'A' ) );
+            Assert.IsTrue( PacketReader.IsSafeChar( '~' ) );
+            Assert.IsFalse( PacketReader.IsSafeChar( 0x00 ) );
+            Assert.IsFalse( PacketReader.IsSafeChar( 0x1F ) );
+            Assert.IsFalse( PacketReader.IsSafeChar( 0xFFFE ) );
+            Assert.IsFalse( PacketReader.IsSafeChar( 0xFFFF ) );
+        }
+
+        [TestMethod]
+        public void SequentialReadsAdvancePosition()
+        {
+            byte[] packet =
+            {
+                0x00, 0x00, 0x0D,
+                0x11, 0x22, 0x33, 0x44,
+                0x55, 0x66,
+                0x77,
+                0x48, 0x69, 0x00
+            };
+
+            PacketReader reader = new PacketReader( packet, packet.Length, false );
+
+            Assert.AreEqual( 3, reader.Index );
+
+            int i32 = reader.ReadInt32();
+            Assert.AreEqual( 0x11223344, i32 );
+            Assert.AreEqual( 7, reader.Index );
+
+            short i16 = reader.ReadInt16();
+            Assert.AreEqual( 0x5566, i16 );
+            Assert.AreEqual( 9, reader.Index );
+
+            byte b = reader.ReadByte();
+            Assert.AreEqual( 0x77, b );
+            Assert.AreEqual( 10, reader.Index );
+
+            string s = reader.ReadString();
+            Assert.AreEqual( "Hi", s );
+        }
+
+        [TestMethod]
+        public void ReadStringEmptyNullTerminated()
+        {
+            byte[] packet = { 0x00, 0x00 };
+            PacketReader reader = new PacketReader( packet, packet.Length, true );
+
+            string result = reader.ReadString();
+
+            Assert.AreEqual( "", result );
+        }
+
+        [TestMethod]
+        public void ReadUnicodeStringEmptyNullTerminated()
+        {
+            byte[] packet = { 0x00, 0x00, 0x00 };
+            PacketReader reader = new PacketReader( packet, packet.Length, true );
+
+            string result = reader.ReadUnicodeString();
+
+            Assert.AreEqual( "", result );
+        }
+
+        [TestMethod]
+        public void ReadUnicodeStringLEEmptyNullTerminated()
+        {
+            byte[] packet = { 0x00, 0x00, 0x00 };
+            PacketReader reader = new PacketReader( packet, packet.Length, true );
+
+            string result = reader.ReadUnicodeStringLE();
+
+            Assert.AreEqual( "", result );
+        }
+
+        [TestMethod]
+        public void ReadByteArrayZeroLength()
+        {
+            byte[] packet = { 0x00, 0xAA };
+            PacketReader reader = new PacketReader( packet, packet.Length, true );
+
+            byte[] result = reader.ReadByteArray( 0 );
+
+            Assert.AreEqual( 0, result.Length );
+            Assert.AreEqual( 1, reader.Index );
+        }
+
+        [TestMethod]
+        public void SeekReturnsNewPosition()
+        {
+            byte[] packet = { 0x00, 0xAA, 0xBB, 0xCC };
+            PacketReader reader = new PacketReader( packet, packet.Length, true );
+
+            long pos = reader.Seek( 3, SeekOrigin.Begin );
+
+            Assert.AreEqual( 3, pos );
+            Assert.AreEqual( 3, reader.Index );
+        }
+
+        [TestMethod]
+        public void ReadMixedTypesFromVariableLengthPacket()
+        {
+            byte[] name = Encoding.ASCII.GetBytes( "Shmoo\0" );
+            byte[] packet = new byte[3 + 4 + 2 + name.Length + 1];
+            packet[0] = 0xAA;
+            packet[1] = 0x00;
+            packet[2] = (byte) packet.Length;
+            packet[3] = 0x00;
+            packet[4] = 0x00;
+            packet[5] = 0x00;
+            packet[6] = 0x01;
+            packet[7] = 0x00;
+            packet[8] = 0x0A;
+            System.Array.Copy( name, 0, packet, 9, name.Length );
+
+            PacketReader reader = new PacketReader( packet, packet.Length, false );
+
+            int serial = reader.ReadInt32();
+            short id = reader.ReadInt16();
+            string readName = reader.ReadString();
+
+            Assert.AreEqual( 1, serial );
+            Assert.AreEqual( 10, id );
+            Assert.AreEqual( "Shmoo", readName );
+        }
+
+        [TestMethod]
+        public void GetDataReturnsIndependentCopy()
+        {
+            byte[] packet = { 0x00, 0xAA, 0xBB };
+            PacketReader reader = new PacketReader( packet, packet.Length, true );
+
+            byte[] data = reader.GetData();
+
+            data[1] = 0xFF;
+
+            byte[] data2 = reader.GetData();
+            Assert.AreEqual( 0xAA, data2[1] );
+        }
+
+        [TestMethod]
+        public void ReadWithSizeSubset()
+        {
+            byte[] packet = { 0x00, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE };
+            PacketReader reader = new PacketReader( packet, 3, true );
+
+            Assert.AreEqual( 3, reader.Size );
+            Assert.AreEqual( 0xAA, reader.ReadByte() );
+            Assert.AreEqual( 0xBB, reader.ReadByte() );
         }
     }
 }

--- a/ClassicAssist/UO/Data/PacketReader.cs
+++ b/ClassicAssist/UO/Data/PacketReader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Text;
 
@@ -6,21 +6,25 @@ namespace ClassicAssist.UO.Data
 {
     public class PacketReader
     {
-        private readonly MemoryStream _stream;
+        private readonly byte[] _data;
+        private readonly int _size;
+        private int _position;
 
         public PacketReader( byte[] data, int size, bool fixedSize )
         {
-            _stream = new MemoryStream( data, 0, size, false );
-
-            _stream.Seek( fixedSize ? 1 : 3, SeekOrigin.Current );
+            _data = data;
+            _size = size;
+            _position = fixedSize ? 1 : 3;
         }
 
-        public long Index => _stream.Position;
-        public long Size => _stream.Length;
+        public long Index => _position;
+        public long Size => _size;
 
         public byte[] GetData()
         {
-            return _stream.ToArray();
+            byte[] copy = new byte[_size];
+            Buffer.BlockCopy( _data, 0, copy, 0, _size );
+            return copy;
         }
 
         public static bool IsSafeChar( int c )
@@ -30,45 +34,64 @@ namespace ClassicAssist.UO.Data
 
         public bool ReadBoolean()
         {
-            return _stream.ReadByte() != 0;
+            if ( _position >= _size )
+            {
+                return false;
+            }
+
+            return _data[_position++] != 0;
         }
 
         public byte ReadByte()
         {
-            return (byte) _stream.ReadByte();
+            if ( _position >= _size )
+            {
+                return 0;
+            }
+
+            return _data[_position++];
         }
 
         public byte[] ReadByteArray( int length )
         {
             byte[] bytes = new byte[length];
+            int available = Math.Min( length, _size - _position );
 
-            for ( int i = 0; i < length; i++ )
+            if ( available > 0 )
             {
-                bytes[i] = ReadByte();
+                Buffer.BlockCopy( _data, _position, bytes, 0, available );
             }
 
+            _position += length;
             return bytes;
         }
 
         public short ReadInt16()
         {
-            byte[] buffer = new byte[2];
-            _stream.Read( buffer, 0, 2 );
-
-            return (short) ( ( buffer[0] << 8 ) | buffer[1] );
+            int b0 = _position < _size ? _data[_position] : 0;
+            int b1 = _position + 1 < _size ? _data[_position + 1] : 0;
+            _position += 2;
+            return (short) ( ( b0 << 8 ) | b1 );
         }
 
         public int ReadInt32()
         {
-            byte[] buffer = new byte[4];
-            _stream.Read( buffer, 0, 4 );
-
-            return ( buffer[0] << 24 ) | ( buffer[1] << 16 ) | ( buffer[2] << 8 ) | buffer[3];
+            int b0 = _position < _size ? _data[_position] : 0;
+            int b1 = _position + 1 < _size ? _data[_position + 1] : 0;
+            int b2 = _position + 2 < _size ? _data[_position + 2] : 0;
+            int b3 = _position + 3 < _size ? _data[_position + 3] : 0;
+            _position += 4;
+            return ( b0 << 24 ) | ( b1 << 16 ) | ( b2 << 8 ) | b3;
         }
 
         public sbyte ReadSByte()
         {
-            return (sbyte) ReadByte();
+            if ( _position >= _size )
+            {
+                return 0;
+            }
+
+            return (sbyte) _data[_position++];
         }
 
         public string ReadString()
@@ -77,7 +100,7 @@ namespace ClassicAssist.UO.Data
 
             int c;
 
-            while ( Index + 1 < Size && ( c = ReadByte() ) != 0 )
+            while ( _position + 1 < _size && ( c = _data[_position++] ) != 0 )
             {
                 sb.Append( (char) c );
             }
@@ -87,11 +110,14 @@ namespace ClassicAssist.UO.Data
 
         public string ReadString( int fixedLength )
         {
-            byte[] buffer = new byte[fixedLength];
+            int available = Math.Min( fixedLength, _size - _position );
 
-            _stream.Read( buffer, 0, fixedLength );
+            string result = available > 0
+                ? Encoding.ASCII.GetString( _data, _position, available ).TrimEnd( '\0' )
+                : string.Empty;
 
-            return Encoding.ASCII.GetString( buffer ).TrimEnd( '\0' );
+            _position += fixedLength;
+            return result;
         }
 
         public string ReadStringSafe()
@@ -103,13 +129,15 @@ namespace ClassicAssist.UO.Data
         {
             StringBuilder output = new StringBuilder();
 
-            for ( int i = 0; i < fixedLength; i++ )
+            int end = _position + fixedLength;
+
+            for ( int i = 0; i < fixedLength && _position < _size; i++ )
             {
-                char c = (char) ReadByte();
+                char c = (char) _data[_position++];
 
                 if ( c == '\0' )
                 {
-                    ReadByteArray( fixedLength - i - 1 );
+                    _position = end;
                     break;
                 }
 
@@ -138,7 +166,7 @@ namespace ClassicAssist.UO.Data
 
             int c;
 
-            while ( Index + 1 < Size && ( c = ( ReadByte() << 8 ) | ReadByte() ) != 0 )
+            while ( _position + 1 < _size && ( c = ( _data[_position++] << 8 ) | _data[_position++] ) != 0 )
             {
                 sb.Append( (char) c );
             }
@@ -148,20 +176,27 @@ namespace ClassicAssist.UO.Data
 
         public string ReadUnicodeString( int fixedLength )
         {
-            byte[] buffer = new byte[fixedLength];
+            int available = Math.Min( fixedLength, _size - _position );
 
-            _stream.Read( buffer, 0, fixedLength );
+            string result = available > 0
+                ? Encoding.Unicode.GetString( _data, _position, available )
+                : string.Empty;
 
-            return Encoding.Unicode.GetString( buffer );
+            _position += fixedLength;
+            return result;
         }
 
         public string ReadUnicodeStringBE( int fixedLength )
         {
-            byte[] buffer = new byte[fixedLength * 2];
+            int byteLength = fixedLength * 2;
+            int available = Math.Min( byteLength, _size - _position );
 
-            _stream.Read( buffer, 0, fixedLength * 2 );
+            string result = available > 0
+                ? Encoding.BigEndianUnicode.GetString( _data, _position, available )
+                : string.Empty;
 
-            return Encoding.BigEndianUnicode.GetString( buffer );
+            _position += byteLength;
+            return result;
         }
 
         public string ReadUnicodeStringLE()
@@ -170,7 +205,7 @@ namespace ClassicAssist.UO.Data
 
             int c;
 
-            while ( Index + 1 < Size && ( c = ReadByte() | ( ReadByte() << 8 ) ) != 0 )
+            while ( _position + 1 < _size && ( c = _data[_position++] | ( _data[_position++] << 8 ) ) != 0 )
             {
                 sb.Append( (char) c );
             }
@@ -200,7 +235,20 @@ namespace ClassicAssist.UO.Data
 
         public long Seek( int offset, SeekOrigin origin )
         {
-            return _stream.Seek( offset, origin );
+            switch ( origin )
+            {
+                case SeekOrigin.Begin:
+                    _position = offset;
+                    break;
+                case SeekOrigin.Current:
+                    _position += offset;
+                    break;
+                case SeekOrigin.End:
+                    _position = _size + offset;
+                    break;
+            }
+
+            return _position;
         }
     }
 }

--- a/ClassicAssist/UO/Network/IncomingPacketHandlers.cs
+++ b/ClassicAssist/UO/Network/IncomingPacketHandlers.cs
@@ -62,6 +62,13 @@ namespace ClassicAssist.UO.Network
         private static PacketHandler[] _handlers;
         private static PacketHandler[] _extendedHandlers;
 
+        private static readonly Version _version6017 = new Version( 6, 0, 1, 7 );
+        private static readonly Version _version7000 = new Version( 7, 0, 0, 0 );
+        private static readonly Version _version70130 = new Version( 7, 0, 13, 0 );
+        private static readonly Version _version70331 = new Version( 7, 0, 33, 1 );
+        private static readonly char[] _tabSeparator = { '\t' };
+        private static readonly XYComparer _xyComparer = new XYComparer();
+
         public static ConcurrentDictionary<int, Property[]> PropertyCache { get; set; } =
             new ConcurrentDictionary<int, Property[]>();
 
@@ -320,7 +327,7 @@ namespace ClassicAssist.UO.Network
 
             int cities = reader.ReadByte();
 
-            bool isNew = Engine.ClientVersion >= new Version( 7, 0, 13, 0 );
+            bool isNew = Engine.ClientVersion >= _version70130;
 
             for ( int i = 0; i < cities; i++ )
             {
@@ -774,7 +781,7 @@ namespace ClassicAssist.UO.Network
             }
 
             List<Item> containerItems = new List<Item>( containerItem.Container.GetItems() );
-            containerItems.Sort( new XYComparer() );
+            containerItems.Sort( _xyComparer );
 
             for ( int i = 0; i < shopList.Count; i++ )
             {
@@ -1004,7 +1011,7 @@ namespace ClassicAssist.UO.Network
 
             HealthbarColour healthbar = HealthbarColour.None;
 
-            if ( Engine.ClientVersion < new Version( 7, 0, 0, 0 ) )
+            if ( Engine.ClientVersion < _version7000 )
             {
                 for ( int i = 0; i < count; i++ )
                 {
@@ -1472,7 +1479,7 @@ namespace ClassicAssist.UO.Network
             int count = reader.ReadUInt16();
             int x = reader.ReadInt16();
             int y = reader.ReadInt16();
-            int grid = Engine.ClientVersion == null || Engine.ClientVersion >= new Version( 6, 0, 1, 7 )
+            int grid = Engine.ClientVersion == null || Engine.ClientVersion >= _version6017
                 ? reader.ReadByte()
                 : 0;
             int containerSerial = reader.ReadInt32();
@@ -1490,8 +1497,7 @@ namespace ClassicAssist.UO.Network
             // Check mobile layer items if container is not a mobile
             if ( !UOMath.IsMobile( containerSerial ) )
             {
-                Layer layer = Engine.Player?.GetAllLayers().Select( ( s, i ) => new { i, s } )
-                    .Where( t => t.s == serial ).Select( t => (Layer) t.i ).FirstOrDefault() ?? Layer.Invalid;
+                Layer layer = FindLayerBySerial( Engine.Player?.GetAllLayers(), serial );
 
                 if ( layer != Layer.Invalid )
                 {
@@ -1499,14 +1505,29 @@ namespace ClassicAssist.UO.Network
                 }
                 else
                 {
-                    Mobile mobile = Engine.Mobiles.SelectEntity( m => m.GetAllLayers().Contains( serial ) );
-
-                    layer = mobile?.GetAllLayers().Select( ( s, i ) => new { i, s } ).Where( t => t.s == serial )
-                        .Select( t => (Layer) t.i ).FirstOrDefault() ?? Layer.Invalid;
-
-                    if ( layer != Layer.Invalid )
+                    Mobile mobile = Engine.Mobiles.SelectEntity( m =>
                     {
-                        mobile?.SetLayer( layer, 0 );
+                        int[] layers = m.GetAllLayers();
+
+                        for ( int i = 0; i < layers.Length; i++ )
+                        {
+                            if ( layers[i] == serial )
+                            {
+                                return true;
+                            }
+                        }
+
+                        return false;
+                    } );
+
+                    if ( mobile != null )
+                    {
+                        layer = FindLayerBySerial( mobile.GetAllLayers(), serial );
+
+                        if ( layer != Layer.Invalid )
+                        {
+                            mobile.SetLayer( layer, 0 );
+                        }
                     }
                 }
             }
@@ -1547,7 +1568,20 @@ namespace ClassicAssist.UO.Network
         {
             int serial = reader.ReadInt32();
 
-            Mobile mobile = Engine.Mobiles.FirstOrDefault( m => m.GetAllLayers().Contains( serial ) );
+            Mobile mobile = Engine.Mobiles.FirstOrDefault( m =>
+            {
+                int[] layers = m.GetAllLayers();
+
+                for ( int i = 0; i < layers.Length; i++ )
+                {
+                    if ( layers[i] == serial )
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            } );
 
             if ( mobile != null )
             {
@@ -1630,7 +1664,7 @@ namespace ClassicAssist.UO.Network
                 int length = reader.ReadInt16();
 
                 property.Arguments = reader.ReadUnicodeString( length )
-                    .Split( new[] { '\t' }, StringSplitOptions.RemoveEmptyEntries );
+                    .Split( _tabSeparator, StringSplitOptions.RemoveEmptyEntries );
 
                 property.Text = Cliloc.GetLocalString( cliloc, property.Arguments );
 
@@ -1777,7 +1811,7 @@ namespace ClassicAssist.UO.Network
             mobile.Status = (MobileStatus) reader.ReadByte();
             mobile.Notoriety = (Notoriety) reader.ReadByte();
 
-            bool useNewIncoming = Engine.ClientVersion == null || Engine.ClientVersion >= new Version( 7, 0, 33, 1 );
+            bool useNewIncoming = Engine.ClientVersion == null || Engine.ClientVersion >= _version70331;
 
             for ( ;; )
             {
@@ -1809,15 +1843,17 @@ namespace ClassicAssist.UO.Network
                 container.Add( item );
             }
 
-            mobile.Equipment.Clear();
-            mobile.Equipment.Add( container.GetItems() );
+            Item[] equippedItems = container.GetItems();
 
-            foreach ( Item item in container.GetItems() )
+            mobile.Equipment.Clear();
+            mobile.Equipment.Add( equippedItems );
+
+            foreach ( Item item in equippedItems )
             {
                 mobile.SetLayer( item.Layer, item.Serial );
             }
 
-            Engine.Items.Add( container.GetItems() );
+            Engine.Items.Add( equippedItems );
 
             if ( !( mobile is PlayerMobile ) )
             {
@@ -2002,6 +2038,24 @@ namespace ClassicAssist.UO.Network
         internal static PacketHandler GetHandler( int packetId )
         {
             return _handlers[packetId];
+        }
+
+        private static Layer FindLayerBySerial( int[] layers, int serial )
+        {
+            if ( layers == null )
+            {
+                return Layer.Invalid;
+            }
+
+            for ( int i = 0; i < layers.Length; i++ )
+            {
+                if ( layers[i] == serial )
+                {
+                    return (Layer) i;
+                }
+            }
+
+            return Layer.Invalid;
         }
 
         private static PacketHandler GetExtendedHandler( int packetId )


### PR DESCRIPTION
PacketReader: Replace MemoryStream with direct byte[] + int position. Eliminates MemoryStream allocation per packet and removes temp byte[] allocations in ReadInt16/ReadInt32 (was 10-80 allocs per packet). Add bounds safety matching old MemoryStream behavior. Expand test coverage from 1 to 35 tests.

IncomingPacketHandlers: Cache Version objects, tab separator, and XYComparer as static readonly fields. Call GetItems() once in OnMobileIncoming instead of 3x. Replace LINQ anonymous type chains in OnItemAddedToContainer and OnItemDeleted with simple for loops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Significantly expanded unit test coverage for packet reading operations, including construction, scalar and bulk reads, string parsing, navigation, and data access.

* **Refactor**
  * Optimised internal packet handling logic to improve performance and reliability. Streamlined network handlers through code restructuring and helper optimisation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->