### PR TITLE
WPF performance: shared resource dictionary and UI virtualization

### DIFF
--- a/ClassicAssist.Controls/FilterControl.xaml
+++ b/ClassicAssist.Controls/FilterControl.xaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:behaviours="clr-namespace:ClassicAssist.Shared.UI.Behaviours;assembly=ClassicAssist.Shared"
              xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d"
              d:DesignHeight="22" d:DesignWidth="200">
     <UserControl.Resources>
@@ -13,8 +14,7 @@
                 <ResourceDictionary Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/Icons.xaml" />
                 <ResourceDictionary
                     Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/Colours.xaml" />
-                <ResourceDictionary
-                    Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>

--- a/ClassicAssist.Controls/MultiValueSelector.xaml
+++ b/ClassicAssist.Controls/MultiValueSelector.xaml
@@ -6,6 +6,7 @@
              xmlns:controls="clr-namespace:ClassicAssist.Controls"
              xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:behaviours="clr-namespace:ClassicAssist.Controls.Misc.Behaviours"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d"
              d:DesignWidth="400">
     <UserControl.Resources>
@@ -14,8 +15,7 @@
                 <ResourceDictionary Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/Icons.xaml" />
                 <ResourceDictionary
                     Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/Colours.xaml" />
-                <ResourceDictionary
-                    Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <DataTemplate x:Key="DefaultItemTemplate">
                 <TextBlock Text="{Binding ., StringFormat={}0x{0:x8}}"

--- a/ClassicAssist.Controls/VirtualFolderBrowse/FolderPromptWindow.xaml
+++ b/ClassicAssist.Controls/VirtualFolderBrowse/FolderPromptWindow.xaml
@@ -4,13 +4,13 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:resources="clr-namespace:ClassicAssist.Shared.Resources;assembly=ClassicAssist.Shared"
+        xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
         mc:Ignorable="d" Topmost="True" Background="{DynamicResource ThemeWindowBackgroundBrush}"
         Title="{x:Static resources:Strings.New_Folder}" Height="150" Width="400">
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary
-                    Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Window.Resources>

--- a/ClassicAssist.Controls/VirtualFolderBrowse/VirtualFolderBrowseWindow.xaml
+++ b/ClassicAssist.Controls/VirtualFolderBrowse/VirtualFolderBrowseWindow.xaml
@@ -7,13 +7,13 @@
         xmlns:virtualFolderBrowse="clr-namespace:ClassicAssist.Controls.VirtualFolderBrowse"
         xmlns:resources="clr-namespace:ClassicAssist.Shared.Resources;assembly=ClassicAssist.Shared"
         xmlns:behaviours="clr-namespace:ClassicAssist.Shared.UI.Behaviours;assembly=ClassicAssist.Shared"
+        xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
         mc:Ignorable="d" Background="{DynamicResource ThemeWindowBackgroundBrush}"
         Title="{x:Static resources:Strings.Folder_Browser}" Height="350" Width="400" Topmost="True">
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary
-                    Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/DarkTheme.xaml" />
                 <ResourceDictionary
                     Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/DebugToolBarStyle.xaml" />
                 <ResourceDictionary>

--- a/ClassicAssist.Launcher/App.xaml
+++ b/ClassicAssist.Launcher/App.xaml
@@ -1,12 +1,12 @@
 ﻿<Application x:Class="ClassicAssist.Launcher.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary
-                    Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/DarkTheme.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/Icons.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <DrawingImage x:Key="PlayIcon">

--- a/ClassicAssist.Shared/UI/SharedResourceDictionary.cs
+++ b/ClassicAssist.Shared/UI/SharedResourceDictionary.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Windows;
+
+namespace ClassicAssist.Shared.UI
+{
+    public class SharedResourceDictionary : ResourceDictionary
+    {
+        private static readonly Dictionary<Uri, ResourceDictionary> _cache =
+            new Dictionary<Uri, ResourceDictionary>();
+
+        private Uri _sourceUri;
+
+        public new Uri Source
+        {
+            get => _sourceUri;
+            set
+            {
+                _sourceUri = value;
+
+                if ( _cache.TryGetValue( value, out ResourceDictionary cached ) )
+                {
+                    MergedDictionaries.Add( cached );
+                    return;
+                }
+
+                base.Source = value;
+                _cache[value] = this;
+            }
+        }
+    }
+}

--- a/ClassicAssist.Updater/App.xaml
+++ b/ClassicAssist.Updater/App.xaml
@@ -1,12 +1,12 @@
 ﻿<Application x:Class="ClassicAssist.Updater.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              StartupUri="MainWindow.xaml" Startup="Application_Startup">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary
-                    Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/DarkTheme.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/Icons.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/ClassicAssist/Browser/MacroBrowserControl.xaml
+++ b/ClassicAssist/Browser/MacroBrowserControl.xaml
@@ -12,6 +12,7 @@
              xmlns:controls2="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls"
              xmlns:headered="clr-namespace:ClassicAssist.Controls.Headered;assembly=ClassicAssist.Controls"
              xmlns:behaviours="clr-namespace:ClassicAssist.UI.Misc.Behaviours"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d"
              d:DesignHeight="550" d:DesignWidth="900">
     <UserControl.DataContext>
@@ -20,7 +21,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../Resources/DarkTheme.xaml" />
                 <ResourceDictionary
                     Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/DebugToolBarStyle.xaml" />
                 <ResourceDictionary Source="../Resources/LeftRightIconToggleButton.xaml" />

--- a/ClassicAssist/Data/Backup/GoogleDrive/GoogleDriveConfigureControl.xaml
+++ b/ClassicAssist/Data/Backup/GoogleDrive/GoogleDriveConfigureControl.xaml
@@ -5,11 +5,12 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:resources="clr-namespace:ClassicAssist.Shared.Resources;assembly=ClassicAssist.Shared"
              xmlns:googleDrive="clr-namespace:ClassicAssist.Data.Backup.GoogleDrive"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary>
                     <Style x:Key="HideIfEmpty" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
                         <Setter Property="Visibility" Value="Visible" />

--- a/ClassicAssist/Data/Backup/Mega/MegaConfigureControl.xaml
+++ b/ClassicAssist/Data/Backup/Mega/MegaConfigureControl.xaml
@@ -6,11 +6,12 @@
              xmlns:resources="clr-namespace:ClassicAssist.Shared.Resources;assembly=ClassicAssist.Shared"
              xmlns:mega="clr-namespace:ClassicAssist.Data.Backup.Mega"
              xmlns:controls="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d" x:Name="Control">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary>
                     <Style x:Key="HideOnLoggedIn" TargetType="Panel">
                         <Setter Property="Visibility" Value="Visible" />

--- a/ClassicAssist/Data/Backup/OneDrive/OneDriveConfigureControl.xaml
+++ b/ClassicAssist/Data/Backup/OneDrive/OneDriveConfigureControl.xaml
@@ -5,11 +5,12 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:ClassicAssist.Data.Backup.OneDrive"
              xmlns:resources="clr-namespace:ClassicAssist.Shared.Resources;assembly=ClassicAssist.Shared"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary>
                     <Style x:Key="HideIfEmpty" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
                         <Setter Property="Visibility" Value="Visible" />

--- a/ClassicAssist/Data/Backup/WebDAV/WebDAVConfigureControl.xaml
+++ b/ClassicAssist/Data/Backup/WebDAV/WebDAVConfigureControl.xaml
@@ -6,6 +6,7 @@
              xmlns:local="clr-namespace:ClassicAssist.Data.Backup.WebDAV"
              xmlns:controls="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls"
              xmlns:resources="clr-namespace:ClassicAssist.Shared.Resources;assembly=ClassicAssist.Shared"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d" x:Name="Control">
     <UserControl.DataContext>
         <local:WebDAVConfigureViewModel />
@@ -13,7 +14,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>

--- a/ClassicAssist/Data/Hotkeys/Commands/ShowChatWindowCommand.cs
+++ b/ClassicAssist/Data/Hotkeys/Commands/ShowChatWindowCommand.cs
@@ -17,8 +17,7 @@
 
 #endregion
 
-using System.Threading;
-using System.Windows.Threading;
+using System;
 using Assistant;
 using ClassicAssist.UI.Views;
 
@@ -29,19 +28,11 @@ namespace ClassicAssist.Data.Hotkeys.Commands
     {
         public override void Execute()
         {
-            Engine.Dispatcher.Invoke( () =>
+            _ = Engine.Dispatcher.BeginInvoke( (Action) ( () =>
             {
-                Thread t = new Thread( () =>
-                {
-                    ChatWindow window = new ChatWindow();
-
-                    window.Show();
-                    Dispatcher.Run();
-                } ) { IsBackground = true };
-
-                t.SetApartmentState( ApartmentState.STA );
-                t.Start();
-            } );
+                ChatWindow window = new ChatWindow();
+                window.Show();
+            } ) );
         }
     }
 }

--- a/ClassicAssist/Data/Hotkeys/Commands/ShowGIFCaptureWindow.cs
+++ b/ClassicAssist/Data/Hotkeys/Commands/ShowGIFCaptureWindow.cs
@@ -17,7 +17,8 @@
 
 #endregion
 
-using System.Threading;
+using System;
+using Assistant;
 using ClassicAssist.UI.Views;
 
 namespace ClassicAssist.Data.Hotkeys.Commands
@@ -29,15 +30,11 @@ namespace ClassicAssist.Data.Hotkeys.Commands
 
         public override void Execute()
         {
-            Thread t = new Thread( () =>
+            _ = Engine.Dispatcher.BeginInvoke( (Action) ( () =>
             {
                 _window = new GIFRecorderWindow();
-                _window.ShowDialog();
-            } );
-
-            t.SetApartmentState( ApartmentState.STA );
-            t.IsBackground = true;
-            t.Start();
+                _window.Show();
+            } ) );
         }
     }
 }

--- a/ClassicAssist/Data/Macros/Commands/MainCommands.cs
+++ b/ClassicAssist/Data/Macros/Commands/MainCommands.cs
@@ -114,16 +114,13 @@ namespace ClassicAssist.Data.Macros.Commands
                 return;
             }
 
-            Thread t = new Thread( () =>
+            _ = Engine.Dispatcher.BeginInvoke( (Action) ( () =>
             {
                 ObjectInspectorWindow window =
                     new ObjectInspectorWindow { DataContext = new ObjectInspectorViewModel( entity ) };
 
                 window.ShowDialog();
-            } ) { IsBackground = true };
-
-            t.SetApartmentState( ApartmentState.STA );
-            t.Start();
+            } ) );
         }
 
         [CommandsDisplay( Category = nameof( Strings.Main ),

--- a/ClassicAssist/UI/Controls/CompletionEntry.xaml
+++ b/ClassicAssist/UI/Controls/CompletionEntry.xaml
@@ -8,11 +8,12 @@
              xmlns:misc="clr-namespace:ClassicAssist.UI.Misc"
              xmlns:resources="clr-namespace:ClassicAssist.Shared.Resources;assembly=ClassicAssist.Shared"
              xmlns:behaviours="clr-namespace:ClassicAssist.UI.Misc.Behaviours"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d" DataContext="{Binding RelativeSource={RelativeSource Self}}">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary>
                     <DrawingImage x:Key="RightChevron">
                         <DrawingImage.Drawing>
@@ -65,7 +66,7 @@
             <Grid.Resources>
                 <ResourceDictionary>
                     <ResourceDictionary.MergedDictionaries>
-                        <ResourceDictionary Source="../../Resources/DarkTheme.xaml" />
+                        <shared:SharedResourceDictionary Source="../../Resources/DarkTheme.xaml" />
                     </ResourceDictionary.MergedDictionaries>
                 </ResourceDictionary>
             </Grid.Resources>

--- a/ClassicAssist/UI/Controls/CompletionEntry.xaml
+++ b/ClassicAssist/UI/Controls/CompletionEntry.xaml
@@ -9,18 +9,19 @@
              xmlns:resources="clr-namespace:ClassicAssist.Shared.Resources;assembly=ClassicAssist.Shared"
              xmlns:behaviours="clr-namespace:ClassicAssist.UI.Misc.Behaviours"
              xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
+             xmlns:po="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
              mc:Ignorable="d" DataContext="{Binding RelativeSource={RelativeSource Self}}">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <shared:SharedResourceDictionary Source="../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary>
-                    <DrawingImage x:Key="RightChevron">
+                    <DrawingImage x:Key="RightChevron" po:Freeze="True">
                         <DrawingImage.Drawing>
                             <DrawingGroup ClipGeometry="M0,0 V256 H256 V0 H0 Z">
                                 <DrawingGroup Opacity="1">
                                     <DrawingGroup Opacity="1">
-                                        <GeometryDrawing Brush="{DynamicResource ThemeForegroundBrush}"
+                                        <GeometryDrawing Brush="{StaticResource ThemeForegroundBrush}"
                                                          Geometry="F1 M256,256z M0,0z M79.093,0L79.093,0 48.907,30.187 146.72,128 48.907,225.813 79.093,256 207.093,128z" />
                                     </DrawingGroup>
                                 </DrawingGroup>
@@ -54,11 +55,11 @@
                 Command="{Binding ToggleExpandedCommand}"
                 Visibility="{Binding IsButtonEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
             <Button.Content>
-                <Image Height="8" Source="{DynamicResource RightChevron}" />
+                <Image Height="8" Source="{StaticResource RightChevron}" />
             </Button.Content>
         </Button>
-        <Grid Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Background="{DynamicResource ThemeWindowBackgroundBrush}"
-              Style="{DynamicResource HideNonExpanded}">
+        <Grid Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Background="{StaticResource ThemeWindowBackgroundBrush}"
+              Style="{StaticResource HideNonExpanded}">
             <Grid.RowDefinitions>
                 <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />

--- a/ClassicAssist/UI/Controls/CustomWindowTitleControl.xaml
+++ b/ClassicAssist/UI/Controls/CustomWindowTitleControl.xaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:behaviours="clr-namespace:ClassicAssist.UI.Misc.Behaviours"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d" x:Name="UserControl"
              d:DesignHeight="50" d:DesignWidth="800"
              Background="{DynamicResource ThemeWindowBackgroundBrush}">
@@ -15,7 +16,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>

--- a/ClassicAssist/UI/Controls/CustomWindowTitleControl.xaml
+++ b/ClassicAssist/UI/Controls/CustomWindowTitleControl.xaml
@@ -36,10 +36,10 @@
         <ContentPresenter Content="{Binding AdditionalContent, ElementName=UserControl}" DockPanel.Dock="Left" />
         <Label DockPanel.Dock="Left" Content="{Binding CustomTitle, ElementName=UserControl}" FontSize="16"
                Margin="5,0,5,0"
-               Foreground="{DynamicResource ThemeForegroundBrush}" />
+               Foreground="{StaticResource ThemeForegroundBrush}" />
         <StackPanel DockPanel.Dock="Right" HorizontalAlignment="Right" Orientation="Horizontal">
             <ContentPresenter Content="{Binding AdditionalButtons, ElementName=UserControl}" />
-            <Button Background="{DynamicResource ThemeWindowBackgroundBrush}"
+            <Button Background="{StaticResource ThemeWindowBackgroundBrush}"
                     IsEnabled="{Binding CanMinimize, ElementName=UserControl}">
                 <i:Interaction.Behaviors>
                     <behaviours:WindowCommandBehaviour Command="Minimize"
@@ -47,14 +47,14 @@
                 </i:Interaction.Behaviors>
                 <Image Source="{StaticResource minusIcon}" />
             </Button>
-            <Button Background="{DynamicResource ThemeWindowBackgroundBrush}"
+            <Button Background="{StaticResource ThemeWindowBackgroundBrush}"
                     IsEnabled="{Binding CanMaximize, ElementName=UserControl}">
                 <i:Interaction.Behaviors>
                     <behaviours:WindowCommandBehaviour Command="Maximize" />
                 </i:Interaction.Behaviors>
                 <Image Source="{StaticResource squareIcon}" />
             </Button>
-            <Button Background="{DynamicResource ThemeWindowBackgroundBrush}"
+            <Button Background="{StaticResource ThemeWindowBackgroundBrush}"
                     IsEnabled="{Binding CanClose, ElementName=UserControl}">
                 <i:Interaction.Behaviors>
                     <behaviours:WindowCommandBehaviour Command="Close" />

--- a/ClassicAssist/UI/ViewModels/HotkeysTabViewModel.cs
+++ b/ClassicAssist/UI/ViewModels/HotkeysTabViewModel.cs
@@ -595,13 +595,16 @@ namespace ClassicAssist.UI.ViewModels
             {
                 spellEntry.Hotkey = ShortcutKeys.Default;
             }
+
+            OnPropertyChanged( nameof( Hotkey ) );
         }
 
-        private static void ClearHotkey( object obj )
+        private void ClearHotkey( object obj )
         {
             if ( obj is HotkeyEntry cmd )
             {
                 cmd.Hotkey = ShortcutKeys.Default;
+                OnPropertyChanged( nameof( Hotkey ) );
             }
         }
 

--- a/ClassicAssist/UI/Views/AboutControl.xaml
+++ b/ClassicAssist/UI/Views/AboutControl.xaml
@@ -8,13 +8,14 @@
              xmlns:valueConverters="clr-namespace:ClassicAssist.UI.Misc.ValueConverters"
              xmlns:headered="clr-namespace:ClassicAssist.Controls.Headered;assembly=ClassicAssist.Controls"
              xmlns:controls="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d"
              d:DesignHeight="350" d:DesignWidth="600"
              d:DataContext="{d:DesignInstance {x:Type viewModels:AboutControlViewModel}, IsDesignTimeCreatable=True}">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>

--- a/ClassicAssist/UI/Views/ActiveObjectsWindow.xaml
+++ b/ClassicAssist/UI/Views/ActiveObjectsWindow.xaml
@@ -9,13 +9,14 @@
     xmlns:misc1="clr-namespace:ClassicAssist.Misc"
     xmlns:valueConverters="clr-namespace:ClassicAssist.UI.Misc.ValueConverters"
     xmlns:behaviours="clr-namespace:ClassicAssist.Shared.UI.Behaviours;assembly=ClassicAssist.Shared"
+    xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
     x:Class="ClassicAssist.UI.Views.ActiveObjectsWindow"
     mc:Ignorable="d" Background="{DynamicResource ThemeWindowBackgroundBrush}"
     Title="{x:Static resources:Strings.Active_Objects}" Height="350" Width="400">
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <valueConverters:IntToHexStringValueConverter x:Key="IntToHexStringValueConverter" />
             <misc1:BindingProxy x:Key="Proxy" Data="{Binding}" />

--- a/ClassicAssist/UI/Views/Agents/Autoloot/Import/CSVImportWindow.xaml
+++ b/ClassicAssist/UI/Views/Agents/Autoloot/Import/CSVImportWindow.xaml
@@ -7,6 +7,7 @@
         xmlns:resources="clr-namespace:ClassicAssist.Shared.Resources;assembly=ClassicAssist.Shared"
         xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:behaviours="clr-namespace:ClassicAssist.Shared.UI.Behaviours;assembly=ClassicAssist.Shared"
+        xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
         mc:Ignorable="d"
         Title="{x:Static resources:Strings.CSV_Import}" Height="350" Width="700"
         Background="{DynamicResource ThemeWindowBackgroundBrush}">
@@ -16,7 +17,7 @@
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Window.Resources>

--- a/ClassicAssist/UI/Views/Agents/AutolootTabControl.xaml
+++ b/ClassicAssist/UI/Views/Agents/AutolootTabControl.xaml
@@ -17,13 +17,14 @@
     xmlns:autoloot1="clr-namespace:ClassicAssist.UI.Views.Autoloot"
     xmlns:autoloot2="clr-namespace:ClassicAssist.UI.Views.Agents.Autoloot"
     xmlns:behaviours1="clr-namespace:ClassicAssist.UI.Misc.Behaviours"
+    xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
     x:Class="ClassicAssist.UI.Views.Agents.AutolootTabControl"
     mc:Ignorable="d"
     d:DesignHeight="250" d:DesignWidth="600" x:Name="userControl">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/Icons.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <misc1:BindingProxy x:Key="Proxy" Data="{Binding}" />

--- a/ClassicAssist/UI/Views/Agents/CountersTabControl.xaml
+++ b/ClassicAssist/UI/Views/Agents/CountersTabControl.xaml
@@ -9,6 +9,7 @@
     xmlns:agents="clr-namespace:ClassicAssist.UI.ViewModels.Agents"
     xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
     xmlns:counters="clr-namespace:ClassicAssist.Data.Counters"
+    xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
     x:Class="ClassicAssist.UI.Views.Agents.CountersTabControl"
     mc:Ignorable="d"
     d:DesignHeight="250" d:DesignWidth="500">
@@ -23,7 +24,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>

--- a/ClassicAssist/UI/Views/Agents/DressTabControl.xaml
+++ b/ClassicAssist/UI/Views/Agents/DressTabControl.xaml
@@ -13,6 +13,7 @@
     xmlns:controls="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls"
     xmlns:draggableListBox="clr-namespace:ClassicAssist.Controls.DraggableListBox;assembly=ClassicAssist.Controls"
     xmlns:behaviours="clr-namespace:ClassicAssist.UI.Misc.Behaviours"
+    xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
     x:Class="ClassicAssist.UI.Views.Agents.DressTabControl"
     mc:Ignorable="d"
     d:DesignHeight="300" d:DesignWidth="500" Margin="0">
@@ -24,7 +25,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <misc:BindingProxy Data="{Binding}" x:Key="Proxy" />
         </ResourceDictionary>

--- a/ClassicAssist/UI/Views/Agents/FriendsTabControl.xaml
+++ b/ClassicAssist/UI/Views/Agents/FriendsTabControl.xaml
@@ -6,6 +6,7 @@
              xmlns:resources="clr-namespace:ClassicAssist.Shared.Resources;assembly=ClassicAssist.Shared"
              xmlns:agents="clr-namespace:ClassicAssist.UI.ViewModels.Agents"
              xmlns:draggableListBox="clr-namespace:ClassicAssist.Controls.DraggableListBox;assembly=ClassicAssist.Controls"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d"
              d:DesignHeight="300">
     <d:DesignerProperties.DesignStyle>
@@ -19,7 +20,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>

--- a/ClassicAssist/UI/Views/Agents/NameOverrideTabControl.xaml
+++ b/ClassicAssist/UI/Views/Agents/NameOverrideTabControl.xaml
@@ -9,6 +9,7 @@
              xmlns:valueConverters="clr-namespace:ClassicAssist.UI.Misc.ValueConverters"
              xmlns:misc="clr-namespace:ClassicAssist.Misc"
              xmlns:nameOverride="clr-namespace:ClassicAssist.Data.NameOverride"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d"
              d:DesignHeight="300" d:DesignWidth="500">
     <d:DesignerProperties.DesignStyle>
@@ -22,7 +23,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <valueConverters:HexToIntValueConverter x:Key="HexToIntValueConverter" />
             <valueConverters:CellWidthValueConverter x:Key="CellWidthValueConverter" />

--- a/ClassicAssist/UI/Views/Agents/Organizer/SourceDestinationOverrideControl.xaml
+++ b/ClassicAssist/UI/Views/Agents/Organizer/SourceDestinationOverrideControl.xaml
@@ -7,6 +7,7 @@
     xmlns:controls="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls"
     xmlns:local="clr-namespace:ClassicAssist.UI.Views.Agents.Organizer"
     xmlns:valueConverters="clr-namespace:ClassicAssist.UI.Misc.ValueConverters"
+    xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
     x:Name="userControl"
     x:Class="ClassicAssist.UI.Views.Agents.Organizer.SourceDestinationOverrideControl"
     mc:Ignorable="d"
@@ -14,7 +15,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/Icons.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <valueConverters:IntToHexStringValueConverter x:Key="IntToHexStringValueConverter" />

--- a/ClassicAssist/UI/Views/Agents/OrganizerTabControl.xaml
+++ b/ClassicAssist/UI/Views/Agents/OrganizerTabControl.xaml
@@ -15,6 +15,7 @@
     xmlns:organizer1="clr-namespace:ClassicAssist.UI.Views.Agents.Organizer"
     xmlns:local="clr-namespace:ClassicAssist.UI.Views.Agents"
     xmlns:behaviours="clr-namespace:ClassicAssist.UI.Misc.Behaviours"
+    xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
     x:Name="userControl" x:Class="ClassicAssist.UI.Views.Agents.OrganizerTabControl"
     mc:Ignorable="d"
     d:DesignHeight="250" d:DesignWidth="500">
@@ -26,7 +27,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>

--- a/ClassicAssist/UI/Views/Agents/Scavenger/ScavengerClilocFilterWindow.xaml
+++ b/ClassicAssist/UI/Views/Agents/Scavenger/ScavengerClilocFilterWindow.xaml
@@ -9,7 +9,8 @@
         xmlns:scavenger="clr-namespace:ClassicAssist.UI.ViewModels.Agents.Scavenger"
         xmlns:scavengerData="clr-namespace:ClassicAssist.Data.Scavenger"
         xmlns:behaviours="clr-namespace:ClassicAssist.Shared.UI.Behaviours;assembly=ClassicAssist.Shared"
-        xmlns:i="http://schemas.microsoft.com/xaml/behaviors" x:Name="Window"
+        xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
+        xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared" x:Name="Window"
         mc:Ignorable="d" Background="{DynamicResource ThemeWindowBackgroundBrush}"
         Foreground="{DynamicResource ThemeForegroundBrush}"
         Title="{x:Static resources:Strings.Cliloc_Filter}" Height="450" Width="400">
@@ -19,7 +20,7 @@
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Window.Resources>

--- a/ClassicAssist/UI/Views/Agents/ScavengerTabControl.xaml
+++ b/ClassicAssist/UI/Views/Agents/ScavengerTabControl.xaml
@@ -65,7 +65,7 @@
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <ListView x:Name="ListView" Grid.Row="0" Margin="10"
-                      ItemsSource="{Binding Items, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                      ItemsSource="{Binding Items}"
                       SelectedItem="{Binding SelectedItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                       Foreground="Black">
                 <ListView.View>

--- a/ClassicAssist/UI/Views/Agents/ScavengerTabControl.xaml
+++ b/ClassicAssist/UI/Views/Agents/ScavengerTabControl.xaml
@@ -9,6 +9,7 @@
              xmlns:controls="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls"
              xmlns:scavenger="clr-namespace:ClassicAssist.Data.Scavenger"
              xmlns:misc="clr-namespace:ClassicAssist.UI.Misc"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d"
              d:DesignWidth="493" d:DesignHeight="400">
     <d:DesignerProperties.DesignStyle>
@@ -22,7 +23,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">
                 <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}" />

--- a/ClassicAssist/UI/Views/Agents/Screenshot/ScreenshotMobileFilterWindow.xaml
+++ b/ClassicAssist/UI/Views/Agents/Screenshot/ScreenshotMobileFilterWindow.xaml
@@ -11,6 +11,7 @@
     xmlns:controls="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls"
     xmlns:valueConverters="clr-namespace:ClassicAssist.Shared.UI.ValueConverters;assembly=ClassicAssist.Shared"
     xmlns:ValueConverters="clr-namespace:ClassicAssist.UI.Misc.ValueConverters"
+    xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
     x:Class="ClassicAssist.UI.Views.Agents.Screenshot.ScreenshotMobileFilterWindow"
     mc:Ignorable="d"
     Title="{x:Static resources:Strings.Screenshot}" Height="450" Width="400"
@@ -18,7 +19,7 @@
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary
                     Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/DebugToolBarStyle.xaml" />
             </ResourceDictionary.MergedDictionaries>

--- a/ClassicAssist/UI/Views/Agents/ScreenshotTabControl.xaml
+++ b/ClassicAssist/UI/Views/Agents/ScreenshotTabControl.xaml
@@ -7,13 +7,14 @@
     xmlns:resources="clr-namespace:ClassicAssist.Shared.Resources;assembly=ClassicAssist.Shared"
     xmlns:valueConverters="clr-namespace:ClassicAssist.UI.Misc.ValueConverters"
     xmlns:ValueConverters="clr-namespace:ClassicAssist.Shared.UI.ValueConverters;assembly=ClassicAssist.Shared"
+    xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
     x:Class="ClassicAssist.UI.Views.Agents.ScreenshotTabControl"
     mc:Ignorable="d"
     d:DesignHeight="450" d:DesignWidth="800">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/Icons.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <ValueConverters:InverseBooleanValueConverter x:Key="InverseBooleanValueConverter" />

--- a/ClassicAssist/UI/Views/Agents/TrapPouchTabControl.xaml
+++ b/ClassicAssist/UI/Views/Agents/TrapPouchTabControl.xaml
@@ -8,13 +8,14 @@
     xmlns:ValueConverters="clr-namespace:ClassicAssist.UI.Misc.ValueConverters"
     xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
     xmlns:trapPouch="clr-namespace:ClassicAssist.Data.TrapPouch"
+    xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
     x:Class="ClassicAssist.UI.Views.Agents.TrapPouchTabControl"
     mc:Ignorable="d"
     d:DesignHeight="300">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <ValueConverters:IntToHexStringValueConverter x:Key="IntToHexStringValueConverter" />
             <agents:TrapPouchTabViewModel x:Key="DummyData" AutoAddTargetedPouches="True">

--- a/ClassicAssist/UI/Views/Agents/VendorBuyTabControl.xaml
+++ b/ClassicAssist/UI/Views/Agents/VendorBuyTabControl.xaml
@@ -9,6 +9,7 @@
     xmlns:controls="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls"
     xmlns:draggableListBox="clr-namespace:ClassicAssist.Controls.DraggableListBox;assembly=ClassicAssist.Controls"
     xmlns:vendors="clr-namespace:ClassicAssist.Data.Vendors"
+    xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
     x:Class="ClassicAssist.UI.Views.Agents.VendorBuyTabControl"
     mc:Ignorable="d"
     d:DesignWidth="493" d:DesignHeight="400">
@@ -20,7 +21,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <ValueConverters:HexToIntValueConverter x:Key="HexToIntValueConverter" />
             <ValueConverters:CellWidthValueConverter x:Key="CellWidthValueConverter" />

--- a/ClassicAssist/UI/Views/Agents/VendorBuyTabControl.xaml
+++ b/ClassicAssist/UI/Views/Agents/VendorBuyTabControl.xaml
@@ -106,7 +106,7 @@
                 </DockPanel>
                 <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled" Grid.Row="1">
                     <ListView x:Name="ListView"
-                              ItemsSource="{Binding SelectedItem.Items, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                              ItemsSource="{Binding SelectedItem.Items}"
                               SelectedItem="{Binding SelectedEntry, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                               Foreground="Black">
                         <ListView.View>

--- a/ClassicAssist/UI/Views/Agents/VendorSellTabControl.xaml
+++ b/ClassicAssist/UI/Views/Agents/VendorSellTabControl.xaml
@@ -11,6 +11,7 @@
              xmlns:misc1="clr-namespace:ClassicAssist.UI.Misc"
              xmlns:vendors="clr-namespace:ClassicAssist.Data.Vendors"
              xmlns:behaviours="clr-namespace:ClassicAssist.UI.Misc.Behaviours"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d"
              d:DesignWidth="493" d:DesignHeight="400">
     <d:DesignerProperties.DesignStyle>
@@ -24,7 +25,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <valueConverters:CellWidthValueConverter x:Key="CellWidthValueConverter" />
             <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource {x:Type TextBlock}}">

--- a/ClassicAssist/UI/Views/Agents/VendorSellTabControl.xaml
+++ b/ClassicAssist/UI/Views/Agents/VendorSellTabControl.xaml
@@ -50,7 +50,7 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <ListView x:Name="ListView" Margin="10" Grid.Row="0"
-                  ItemsSource="{Binding Items, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                  ItemsSource="{Binding Items}"
                   SelectedItem="{Binding SelectedItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                   Foreground="Black" Grid.IsSharedSizeScope="True">
             <ListView.View>

--- a/ClassicAssist/UI/Views/AutologinStatusWindow.xaml
+++ b/ClassicAssist/UI/Views/AutologinStatusWindow.xaml
@@ -7,13 +7,14 @@
         xmlns:viewModels="clr-namespace:ClassicAssist.UI.ViewModels"
         xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:behaviours="clr-namespace:ClassicAssist.Shared.UI.Behaviours;assembly=ClassicAssist.Shared"
+        xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
         mc:Ignorable="d" Topmost="True" WindowStartupLocation="CenterScreen"
         Title="{x:Static resources:Strings.Autologin}" Width="400" Height="300"
         Background="{DynamicResource ThemeWindowBackgroundBrush}" ResizeMode="NoResize">
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Window.Resources>

--- a/ClassicAssist/UI/Views/Autoloot/AutolootValueControl.xaml
+++ b/ClassicAssist/UI/Views/Autoloot/AutolootValueControl.xaml
@@ -3,12 +3,13 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800" DataContextChanged="OnDataContextChanged">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/Icons.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/ClassicAssist/UI/Views/Autoloot/ClilocSelectionWindow.xaml
+++ b/ClassicAssist/UI/Views/Autoloot/ClilocSelectionWindow.xaml
@@ -7,6 +7,7 @@
         xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:autoloot="clr-namespace:ClassicAssist.UI.ViewModels.Autoloot"
         xmlns:behaviours="clr-namespace:ClassicAssist.Shared.UI.Behaviours;assembly=ClassicAssist.Shared"
+        xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
         mc:Ignorable="d"
         Title="{x:Static resources:Strings.Choose_by_Cliloc}" Height="350" Width="450"
         Background="{DynamicResource ThemeWindowBackgroundBrush}" Topmost="True">
@@ -16,7 +17,7 @@
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Window.Resources>

--- a/ClassicAssist/UI/Views/Autoloot/CustomPropertiesWindow.xaml
+++ b/ClassicAssist/UI/Views/Autoloot/CustomPropertiesWindow.xaml
@@ -9,6 +9,7 @@
         xmlns:behaviours="clr-namespace:ClassicAssist.Shared.UI.Behaviours;assembly=ClassicAssist.Shared"
         xmlns:controls="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls"
         xmlns:valueConverters="clr-namespace:ClassicAssist.Shared.UI.ValueConverters;assembly=ClassicAssist.Shared"
+        xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
         mc:Ignorable="d"
         Title="{x:Static resources:Strings.Define_Custom_Properties}" Height="350" Width="725"
         Background="{DynamicResource ThemeWindowBackgroundBrush}" Topmost="True">
@@ -18,7 +19,7 @@
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
             <valueConverters:CellWidthValueConverter x:Key="CellWidthValueConverter" />

--- a/ClassicAssist/UI/Views/Autoloot/PropertySelectionWindow.xaml
+++ b/ClassicAssist/UI/Views/Autoloot/PropertySelectionWindow.xaml
@@ -7,13 +7,14 @@
         xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:autoloot="clr-namespace:ClassicAssist.UI.ViewModels.Autoloot"
         xmlns:behaviours="clr-namespace:ClassicAssist.Shared.UI.Behaviours;assembly=ClassicAssist.Shared"
+        xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
         mc:Ignorable="d"
         Title="{x:Static resources:Strings.Choose_from_Item}" Height="250" Width="400"
         Background="{DynamicResource ThemeWindowBackgroundBrush}" Topmost="True">
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Window.Resources>

--- a/ClassicAssist/UI/Views/BackupSettingsWindow.xaml
+++ b/ClassicAssist/UI/Views/BackupSettingsWindow.xaml
@@ -9,6 +9,7 @@
         xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
         xmlns:behaviours="clr-namespace:ClassicAssist.Shared.UI.Behaviours;assembly=ClassicAssist.Shared"
         xmlns:validationRules="clr-namespace:ClassicAssist.Shared.UI.ValidationRules;assembly=ClassicAssist.Shared"
+        xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
         mc:Ignorable="d" Topmost="True" SizeToContent="Height"
         Title="{x:Static resources:Strings.Backup_Settings}" MinHeight="350" Width="400"
         Background="{DynamicResource ThemeWindowBackgroundBrush}">
@@ -18,7 +19,7 @@
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary>
                     <Style x:Key="Login" TargetType="{x:Type ContentControl}">
                         <Setter Property="Visibility" Value="Visible" />

--- a/ClassicAssist/UI/Views/BackupWindow.xaml
+++ b/ClassicAssist/UI/Views/BackupWindow.xaml
@@ -7,13 +7,14 @@
         xmlns:resources="clr-namespace:ClassicAssist.Shared.Resources;assembly=ClassicAssist.Shared"
         xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:behaviours="clr-namespace:ClassicAssist.Shared.UI.Behaviours;assembly=ClassicAssist.Shared"
+        xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
         mc:Ignorable="d" Background="{DynamicResource ThemeWindowBackgroundBrush}"
         WindowStartupLocation="CenterScreen"
         Title="{x:Static resources:Strings.Profile_Backup}" Height="500" Width="600">
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary>
                     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
                 </ResourceDictionary>

--- a/ClassicAssist/UI/Views/ChatWindow.xaml
+++ b/ClassicAssist/UI/Views/ChatWindow.xaml
@@ -9,6 +9,7 @@
         xmlns:controls="clr-namespace:ClassicAssist.UI.Controls"
         xmlns:behaviours="clr-namespace:ClassicAssist.Shared.UI.Behaviours;assembly=ClassicAssist.Shared"
         xmlns:behaviours1="clr-namespace:ClassicAssist.UI.Misc.Behaviours"
+        xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
         mc:Ignorable="d"
         Title="{Binding Title}" Height="350" Width="650" Background="{DynamicResource ThemeWindowBackgroundBrush}"
         Topmost="{Binding Topmost}" WindowStyle="None" ResizeMode="CanResizeWithGrip" AllowsTransparency="True">
@@ -18,7 +19,7 @@
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary>
                     <DrawingImage x:Key="PersonIcon">
                         <DrawingImage.Drawing>

--- a/ClassicAssist/UI/Views/ChatWindow.xaml
+++ b/ClassicAssist/UI/Views/ChatWindow.xaml
@@ -57,21 +57,30 @@
                     <RowDefinition Height="*" />
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
-                <ScrollViewer x:Name="ScrollViewer" Grid.Row="0">
-                    <ItemsControl Background="{DynamicResource ThemeBackgroundBrush}"
-                                  ItemsSource="{Binding Messages}" ScrollViewer.VerticalScrollBarVisibility="Visible">
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate>
-                                <TextBlock Text="{Binding}" Margin="5" Foreground="{Binding Colour}"
-                                           VerticalAlignment="Center" TextWrapping="WrapWithOverflow" />
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                        <i:Interaction.Behaviors>
-                            <behaviours:ItemsControlAutoScrollBehaviour
-                                ScrollViewer="{Binding ElementName=ScrollViewer}" />
-                        </i:Interaction.Behaviors>
-                    </ItemsControl>
-                </ScrollViewer>
+                <ListBox Grid.Row="0" Background="{DynamicResource ThemeBackgroundBrush}"
+                         ItemsSource="{Binding Messages}"
+                         ScrollViewer.VerticalScrollBarVisibility="Visible"
+                         ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                         HorizontalContentAlignment="Stretch"
+                         VirtualizingStackPanel.IsVirtualizing="True"
+                         VirtualizingStackPanel.VirtualizationMode="Recycling">
+                    <ListBox.ItemContainerStyle>
+                        <Style TargetType="{x:Type ListBoxItem}">
+                            <Setter Property="Padding" Value="0" />
+                            <Setter Property="Focusable" Value="False" />
+                            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                        </Style>
+                    </ListBox.ItemContainerStyle>
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding}" Margin="5" Foreground="{Binding Colour}"
+                                       VerticalAlignment="Center" TextWrapping="WrapWithOverflow" />
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                    <i:Interaction.Behaviors>
+                        <behaviours:ItemsControlAutoScrollBehaviour />
+                    </i:Interaction.Behaviors>
+                </ListBox>
                 <TextBox Grid.Row="1" KeyDown="TextBox_KeyDown" />
             </Grid>
             <GridSplitter Grid.Column="1" ResizeDirection="Columns"

--- a/ClassicAssist/UI/Views/Debug/DebugActionQueueControl.xaml
+++ b/ClassicAssist/UI/Views/Debug/DebugActionQueueControl.xaml
@@ -8,6 +8,7 @@
              xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:behaviours="clr-namespace:ClassicAssist.Shared.UI.Behaviours;assembly=ClassicAssist.Shared"
              xmlns:controls="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d" Background="{DynamicResource ThemeBackgroundBrush}"
              d:DesignHeight="400" d:DesignWidth="550">
     <UserControl.DataContext>
@@ -16,7 +17,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary Source="Styles.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/ClassicAssist/UI/Views/Debug/DebugAssembliesControl.xaml
+++ b/ClassicAssist/UI/Views/Debug/DebugAssembliesControl.xaml
@@ -7,6 +7,7 @@
              xmlns:resources="clr-namespace:ClassicAssist.Shared.Resources;assembly=ClassicAssist.Shared"
              xmlns:valueConverters="clr-namespace:ClassicAssist.UI.Misc.ValueConverters"
              xmlns:reflection="clr-namespace:System.Reflection;assembly=mscorlib"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d" Background="{DynamicResource ThemeBackgroundBrush}"
              d:DesignHeight="250" d:DesignWidth="300">
     <UserControl.DataContext>
@@ -15,7 +16,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary Source="Styles.xaml" />
                 <ResourceDictionary>
                     <valueConverters:CellWidthValueConverter x:Key="CellWidthValueConverter" />

--- a/ClassicAssist/UI/Views/Debug/DebugAutolootControl.xaml
+++ b/ClassicAssist/UI/Views/Debug/DebugAutolootControl.xaml
@@ -8,12 +8,13 @@
              xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:controls="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls"
              xmlns:behaviours="clr-namespace:ClassicAssist.UI.Misc.Behaviours"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d" Background="{DynamicResource ThemeBackgroundBrush}"
              d:DesignHeight="400" d:DesignWidth="550">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary Source="Styles.xaml" />
                 <ResourceDictionary>
                     <DrawingImage x:Key="ContainerIcon">

--- a/ClassicAssist/UI/Views/Debug/DebugBuffIconsControl.xaml
+++ b/ClassicAssist/UI/Views/Debug/DebugBuffIconsControl.xaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:debug="clr-namespace:ClassicAssist.UI.ViewModels.Debug"
              xmlns:controls="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d" Background="{DynamicResource ThemeBackgroundBrush}"
              d:DesignHeight="400" d:DesignWidth="550">
     <UserControl.DataContext>
@@ -13,7 +14,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary Source="Styles.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/ClassicAssist/UI/Views/Debug/DebugGumpControl.xaml
+++ b/ClassicAssist/UI/Views/Debug/DebugGumpControl.xaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:debug="clr-namespace:ClassicAssist.UI.ViewModels.Debug"
              xmlns:controls="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d" Background="{DynamicResource ThemeBackgroundBrush}"
              d:DesignHeight="400" d:DesignWidth="550">
     <UserControl.DataContext>
@@ -13,7 +14,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary Source="Styles.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/ClassicAssist/UI/Views/Debug/DebugJournalControl.xaml
+++ b/ClassicAssist/UI/Views/Debug/DebugJournalControl.xaml
@@ -8,6 +8,7 @@
              xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:behaviours="clr-namespace:ClassicAssist.Shared.UI.Behaviours;assembly=ClassicAssist.Shared"
              xmlns:controls="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d" Background="{DynamicResource ThemeBackgroundBrush}"
              d:DesignHeight="300" d:DesignWidth="350">
     <UserControl.DataContext>
@@ -16,7 +17,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary Source="Styles.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/ClassicAssist/UI/Views/Debug/DebugKeyboardControl.xaml
+++ b/ClassicAssist/UI/Views/Debug/DebugKeyboardControl.xaml
@@ -6,6 +6,7 @@
              xmlns:resources="clr-namespace:ClassicAssist.Shared.Resources;assembly=ClassicAssist.Shared"
              xmlns:misc="clr-namespace:ClassicAssist.Misc"
              xmlns:debug="clr-namespace:ClassicAssist.UI.ViewModels.Debug"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              Background="{DynamicResource ThemeBackgroundBrush}"
              mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800"
@@ -13,7 +14,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary Source="Styles.xaml" />
                 <ResourceDictionary>
                     <misc:BindingProxy x:Key="Proxy" Data="{Binding}" />

--- a/ClassicAssist/UI/Views/Debug/DebugMenusControl.xaml
+++ b/ClassicAssist/UI/Views/Debug/DebugMenusControl.xaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:debug="clr-namespace:ClassicAssist.UI.ViewModels.Debug"
              xmlns:controls="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d" Background="{DynamicResource ThemeBackgroundBrush}"
              d:DesignHeight="400" d:DesignWidth="550">
     <UserControl.DataContext>
@@ -13,7 +14,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary Source="Styles.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/ClassicAssist/UI/Views/Debug/DebugPacketQueueControl.xaml
+++ b/ClassicAssist/UI/Views/Debug/DebugPacketQueueControl.xaml
@@ -8,11 +8,12 @@
              xmlns:debug="clr-namespace:ClassicAssist.UI.ViewModels.Debug"
              xmlns:resources="clr-namespace:ClassicAssist.Shared.Resources;assembly=ClassicAssist.Shared"
              xmlns:controls="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d" d:DesignHeight="400" d:DesignWidth="550">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary Source="../Debug/Styles.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/ClassicAssist/UI/Views/Debug/DebugPacketsControl.xaml
+++ b/ClassicAssist/UI/Views/Debug/DebugPacketsControl.xaml
@@ -13,12 +13,13 @@
              xmlns:headered="clr-namespace:ClassicAssist.Controls.Headered;assembly=ClassicAssist.Controls"
              xmlns:misc="clr-namespace:ClassicAssist.UI.Misc"
              xmlns:packetFilter="clr-namespace:ClassicAssist.UO.Network.PacketFilter"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary Source="../Debug/Styles.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/ClassicAssist/UI/Views/Debug/DebugPropertiesControl.xaml
+++ b/ClassicAssist/UI/Views/Debug/DebugPropertiesControl.xaml
@@ -9,12 +9,13 @@
              xmlns:misc="clr-namespace:ClassicAssist.UI.Misc"
              xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:behaviours="clr-namespace:ClassicAssist.UI.Misc.Behaviours"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d" Background="{DynamicResource ThemeBackgroundBrush}"
              d:DesignHeight="450" d:DesignWidth="800">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary Source="Styles.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <debug:JoinArrayValueConverter x:Key="JoinArrayValueConverter" />

--- a/ClassicAssist/UI/Views/Debug/DebugSpecialMovesControl.xaml
+++ b/ClassicAssist/UI/Views/Debug/DebugSpecialMovesControl.xaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:debug="clr-namespace:ClassicAssist.UI.ViewModels.Debug"
              xmlns:controls="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d" Background="{DynamicResource ThemeBackgroundBrush}"
              d:DesignHeight="400" d:DesignWidth="550">
     <UserControl.DataContext>
@@ -13,7 +14,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary Source="Styles.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/ClassicAssist/UI/Views/Debug/DebugVendorBuyControl.xaml
+++ b/ClassicAssist/UI/Views/Debug/DebugVendorBuyControl.xaml
@@ -7,6 +7,7 @@
              xmlns:resources="clr-namespace:ClassicAssist.Shared.Resources;assembly=ClassicAssist.Shared"
              xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:behaviours="clr-namespace:ClassicAssist.Shared.UI.Behaviours;assembly=ClassicAssist.Shared"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d" Background="{DynamicResource ThemeBackgroundBrush}"
              d:DesignHeight="450" d:DesignWidth="800">
     <UserControl.DataContext>
@@ -15,7 +16,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary Source="Styles.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/ClassicAssist/UI/Views/Debug/Styles.xaml
+++ b/ClassicAssist/UI/Views/Debug/Styles.xaml
@@ -1,8 +1,9 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:sharedControls="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls">
+                    xmlns:sharedControls="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls"
+                    xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared">
     <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+        <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
         <ResourceDictionary
             Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/DebugToolBarStyle.xaml" />
         <ResourceDictionary>

--- a/ClassicAssist/UI/Views/DebugWindow.xaml
+++ b/ClassicAssist/UI/Views/DebugWindow.xaml
@@ -5,6 +5,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:resources="clr-namespace:ClassicAssist.Shared.Resources;assembly=ClassicAssist.Shared"
     xmlns:debug="clr-namespace:ClassicAssist.UI.Views.Debug"
+    xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
     x:Name="window"
     x:Class="ClassicAssist.UI.Views.DebugWindow"
     mc:Ignorable="d"
@@ -13,7 +14,7 @@
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary Source="Debug/Styles.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/ClassicAssist/UI/Views/ECV/EntityCollectionViewerOrganizerControl.xaml
+++ b/ClassicAssist/UI/Views/ECV/EntityCollectionViewerOrganizerControl.xaml
@@ -6,6 +6,7 @@
              xmlns:local="clr-namespace:ClassicAssist.UI.Views.ECV"
              xmlns:resources="clr-namespace:ClassicAssist.Shared.Resources;assembly=ClassicAssist.Shared"
              xmlns:controls="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d">
     <UserControl.DataContext>
         <local:EntityCollectionViewerOrganizerViewModel />
@@ -13,7 +14,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>

--- a/ClassicAssist/UI/Views/ECV/EntityCollectionViewerSettingsWindow.xaml
+++ b/ClassicAssist/UI/Views/ECV/EntityCollectionViewerSettingsWindow.xaml
@@ -9,6 +9,7 @@
         xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:behaviours="clr-namespace:ClassicAssist.Shared.UI.Behaviours;assembly=ClassicAssist.Shared"
         xmlns:controls="clr-namespace:ClassicAssist.UI.Views.ECV.Settings.Controls"
+        xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
         mc:Ignorable="d"
         Title="{x:Static resources:Strings.Entity_Collection_Viewer}"
         Background="{DynamicResource ThemeWindowBackgroundBrush}"
@@ -19,7 +20,7 @@
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Window.Resources>

--- a/ClassicAssist/UI/Views/ECV/Filter/Styles.xaml
+++ b/ClassicAssist/UI/Views/ECV/Filter/Styles.xaml
@@ -2,9 +2,10 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:valueConverters="clr-namespace:ClassicAssist.Shared.UI.ValueConverters;assembly=ClassicAssist.Shared"
                     xmlns:localValueConverters="clr-namespace:ClassicAssist.UI.Views.ECV.Filter.ValueConverters"
-                    xmlns:controls="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls">
+                    xmlns:controls="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls"
+                    xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared">
     <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="../../../../Resources/DarkTheme.xaml" />
+        <shared:SharedResourceDictionary Source="../../../../Resources/DarkTheme.xaml" />
         <ResourceDictionary>
             <DrawingImage x:Key="PlusIcon">
                 <DrawingImage.Drawing>

--- a/ClassicAssist/UI/Views/ECV/Settings/CombineStacksSettingsControl.xaml
+++ b/ClassicAssist/UI/Views/ECV/Settings/CombineStacksSettingsControl.xaml
@@ -8,13 +8,14 @@
     xmlns:controls="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls"
     xmlns:settingsControls="clr-namespace:ClassicAssist.UI.Views.ECV.Settings.Controls"
     xmlns:models="clr-namespace:ClassicAssist.UI.Views.ECV.Settings.Models"
+    xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
     x:Class="ClassicAssist.UI.Views.ECV.Settings.CombineStacksSettingsControl"
     mc:Ignorable="d"
     Background="Transparent">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary
                     Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/DebugToolBarStyle.xaml" />
             </ResourceDictionary.MergedDictionaries>

--- a/ClassicAssist/UI/Views/ECV/Settings/ContainerSetsSettingsControl.xaml
+++ b/ClassicAssist/UI/Views/ECV/Settings/ContainerSetsSettingsControl.xaml
@@ -7,11 +7,12 @@
              xmlns:valueConverters="clr-namespace:ClassicAssist.Shared.UI.ValueConverters;assembly=ClassicAssist.Shared"
              xmlns:valueConverters1="clr-namespace:ClassicAssist.UI.Misc.ValueConverters"
              xmlns:dd="urn:gong-wpf-dragdrop"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary
                     Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/DebugToolBarStyle.xaml" />
                 <ResourceDictionary Source="../../ECV/Icons.xaml" />

--- a/ClassicAssist/UI/Views/ECV/Settings/Controls/EditTextBlocks/ClilocEditTextBlock.xaml
+++ b/ClassicAssist/UI/Views/ECV/Settings/Controls/EditTextBlocks/ClilocEditTextBlock.xaml
@@ -7,12 +7,13 @@
              xmlns:controls="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls"
              xmlns:resources="clr-namespace:ClassicAssist.Shared.Resources;assembly=ClassicAssist.Shared"
              xmlns:editTextBlocks="clr-namespace:ClassicAssist.UI.Views.ECV.Settings.Controls.EditTextBlocks"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d"
              d:DesignWidth="300">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary Source="../../../../Debug/Styles.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/ClassicAssist/UI/Views/ECV/Settings/Controls/EditTextBlocks/GraphicEditTextBlock.xaml
+++ b/ClassicAssist/UI/Views/ECV/Settings/Controls/EditTextBlocks/GraphicEditTextBlock.xaml
@@ -8,12 +8,13 @@
              xmlns:settingsValueConverters="clr-namespace:ClassicAssist.UI.Views.ECV.Settings.ValueConverters"
              xmlns:valueConverters="clr-namespace:ClassicAssist.UI.Misc.ValueConverters"
              xmlns:editTextBlocks="clr-namespace:ClassicAssist.UI.Views.ECV.Settings.Controls.EditTextBlocks"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d"
              d:DesignWidth="400">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary Source="../../../../Debug/Styles.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <settingsValueConverters:GraphicValueConverter x:Key="GraphicValueConverter" />

--- a/ClassicAssist/UI/Views/ECV/Settings/Controls/IgnoreSettingsListViewControl.xaml
+++ b/ClassicAssist/UI/Views/ECV/Settings/Controls/IgnoreSettingsListViewControl.xaml
@@ -10,12 +10,13 @@
              xmlns:valueConverters="clr-namespace:ClassicAssist.Shared.UI.ValueConverters;assembly=ClassicAssist.Shared"
              xmlns:editTextBlocks="clr-namespace:ClassicAssist.UI.Views.ECV.Settings.Controls.EditTextBlocks"
              xmlns:models="clr-namespace:ClassicAssist.UI.Views.ECV.Settings.Models"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d"
              d:DesignWidth="800">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary
                     Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/DebugToolBarStyle.xaml" />
             </ResourceDictionary.MergedDictionaries>

--- a/ClassicAssist/UI/Views/ECV/Settings/OpenContainersSettingsControl.xaml
+++ b/ClassicAssist/UI/Views/ECV/Settings/OpenContainersSettingsControl.xaml
@@ -8,13 +8,14 @@
     xmlns:controls="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls"
     xmlns:settingsControls="clr-namespace:ClassicAssist.UI.Views.ECV.Settings.Controls"
     xmlns:models="clr-namespace:ClassicAssist.UI.Views.ECV.Settings.Models"
+    xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
     x:Class="ClassicAssist.UI.Views.ECV.Settings.OpenContainersSettingsControl"
     mc:Ignorable="d"
     Background="Transparent">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary
                     Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/DebugToolBarStyle.xaml" />
             </ResourceDictionary.MergedDictionaries>

--- a/ClassicAssist/UI/Views/EntityCollectionViewer.xaml
+++ b/ClassicAssist/UI/Views/EntityCollectionViewer.xaml
@@ -13,6 +13,7 @@
     xmlns:ecv="clr-namespace:ClassicAssist.UI.Views.ECV"
     xmlns:local="clr-namespace:ClassicAssist.UI.Views"
     xmlns:behaviours="clr-namespace:ClassicAssist.UI.Misc.Behaviours"
+    xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
     x:Name="window"
     x:Class="ClassicAssist.UI.Views.EntityCollectionViewer"
     mc:Ignorable="d" Background="{DynamicResource ThemeBackgroundBrush}"
@@ -23,7 +24,7 @@
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary
                     Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/DebugToolBarStyle.xaml" />
                 <ResourceDictionary Source="ECV/Icons.xaml" />

--- a/ClassicAssist/UI/Views/EntityCollectionViewer.xaml
+++ b/ClassicAssist/UI/Views/EntityCollectionViewer.xaml
@@ -167,7 +167,7 @@
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
-                        <TextBlock Text="{Binding Status}" Foreground="{DynamicResource ThemeForegroundBrush}"
+                        <TextBlock Text="{Binding Status}" Foreground="{StaticResource ThemeForegroundBrush}"
                                    Padding="3,0,0,0"
                                    Grid.Column="0" VerticalAlignment="Center" />
                         <Button Command="{Binding CancelCommand}" BorderThickness="0" BorderBrush="Transparent"

--- a/ClassicAssist/UI/Views/Filters/ClilocFilterConfigureWindow.xaml
+++ b/ClassicAssist/UI/Views/Filters/ClilocFilterConfigureWindow.xaml
@@ -10,6 +10,7 @@
         xmlns:misc="clr-namespace:ClassicAssist.Misc"
         xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:behaviours="clr-namespace:ClassicAssist.Shared.UI.Behaviours;assembly=ClassicAssist.Shared"
+        xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
         mc:Ignorable="d" WindowStartupLocation="CenterScreen" Background="{DynamicResource ThemeWindowBackgroundBrush}"
         Title="{x:Static resources:Strings.Cliloc_Filter}" Height="450" Width="625">
     <Window.DataContext>
@@ -18,7 +19,7 @@
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary Source="../Debug/Styles.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <valueConverters:CellWidthValueConverter x:Key="CellWidthValueConverter" />

--- a/ClassicAssist/UI/Views/Filters/ItemIDFilter/ItemIDSelectionWindow.xaml
+++ b/ClassicAssist/UI/Views/Filters/ItemIDFilter/ItemIDSelectionWindow.xaml
@@ -7,13 +7,14 @@
         xmlns:valueConverters="clr-namespace:ClassicAssist.UI.Misc.ValueConverters"
         xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:behaviours="clr-namespace:ClassicAssist.Shared.UI.Behaviours;assembly=ClassicAssist.Shared"
+        xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
         mc:Ignorable="d" Background="{DynamicResource ThemeWindowBackgroundBrush}"
         Title="{x:Static resources:Strings.ItemID_Filter}" Height="450" Width="300"
         DataContext="{Binding Mode=OneWay, RelativeSource={RelativeSource Self}}">
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <DrawingImage x:Key="LoadIcon">
                 <DrawingImage.Drawing>

--- a/ClassicAssist/UI/Views/Filters/ItemIDFilter/ItemIDTooltipControl.xaml
+++ b/ClassicAssist/UI/Views/Filters/ItemIDFilter/ItemIDTooltipControl.xaml
@@ -4,12 +4,13 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:valueConverters="clr-namespace:ClassicAssist.UI.Misc.ValueConverters"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <valueConverters:IntToHexStringValueConverter x:Key="IntToHexStringValueConverter" />
         </ResourceDictionary>

--- a/ClassicAssist/UI/Views/Filters/ItemIDFilterConfigureWindow.xaml
+++ b/ClassicAssist/UI/Views/Filters/ItemIDFilterConfigureWindow.xaml
@@ -12,12 +12,13 @@
         xmlns:misc="clr-namespace:ClassicAssist.Misc"
         xmlns:filters1="clr-namespace:ClassicAssist.Data.Filters"
         xmlns:itemIdFilter="clr-namespace:ClassicAssist.UI.Views.Filters.ItemIDFilter"
+        xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
         mc:Ignorable="d" Background="{DynamicResource ThemeWindowBackgroundBrush}"
         Title="{x:Static resources:Strings.ItemID_Filter}" Height="350" Width="420">
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary
                     Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/DebugToolBarStyle.xaml" />
                 <ResourceDictionary>

--- a/ClassicAssist/UI/Views/Filters/RepeatedMessagesFilterConfigureWindow.xaml
+++ b/ClassicAssist/UI/Views/Filters/RepeatedMessagesFilterConfigureWindow.xaml
@@ -7,6 +7,7 @@
         xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
         xmlns:behaviours="clr-namespace:ClassicAssist.Shared.UI.Behaviours;assembly=ClassicAssist.Shared"
+        xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
         Topmost="True"
         mc:Ignorable="d" Background="{DynamicResource ThemeWindowBackgroundBrush}"
         DataContext="{Binding Mode=OneWay, RelativeSource={RelativeSource Self}}"
@@ -14,7 +15,7 @@
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Window.Resources>

--- a/ClassicAssist/UI/Views/Filters/SeasonFilterConfigureWindow.xaml
+++ b/ClassicAssist/UI/Views/Filters/SeasonFilterConfigureWindow.xaml
@@ -8,13 +8,14 @@
         xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:misc="clr-namespace:ClassicAssist.UI.Misc"
         xmlns:filters="clr-namespace:ClassicAssist.Data.Filters"
+        xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
         mc:Ignorable="d" Background="{DynamicResource ThemeWindowBackgroundBrush}"
         Title="{x:Static resources:Strings.Seasons}" Width="400" SizeToContent="Height"
         DataContext="{Binding Mode=OneWay, RelativeSource={RelativeSource Self}}" Topmost="True">
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Window.Resources>

--- a/ClassicAssist/UI/Views/Filters/SoundFilterConfigureWindow.xaml
+++ b/ClassicAssist/UI/Views/Filters/SoundFilterConfigureWindow.xaml
@@ -7,13 +7,14 @@
         xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:behaviours="clr-namespace:ClassicAssist.Shared.UI.Behaviours;assembly=ClassicAssist.Shared"
         xmlns:filters="clr-namespace:ClassicAssist.Data.Filters"
+        xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
         mc:Ignorable="d" Background="{DynamicResource ThemeWindowBackgroundBrush}"
         Title="{x:Static resources:Strings.Configure_Sound_Filters}" Height="500" Width="400"
         DataContext="{Binding Mode=OneWay, RelativeSource={RelativeSource Self}}" Topmost="True">
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary>
                     <CollectionViewSource x:Key='src' Source="{Binding Items}">
                         <CollectionViewSource.GroupDescriptions>

--- a/ClassicAssist/UI/Views/General/AutologinConfigureWindow.xaml
+++ b/ClassicAssist/UI/Views/General/AutologinConfigureWindow.xaml
@@ -8,6 +8,7 @@
         xmlns:behaviours="clr-namespace:ClassicAssist.Shared.UI.Behaviours;assembly=ClassicAssist.Shared"
         xmlns:general="clr-namespace:ClassicAssist.UI.Views.General"
         xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
+        xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
         mc:Ignorable="d"
         Title="{x:Static resources:Strings.Autologin}" Width="300" SizeToContent="Height"
         Background="{DynamicResource WindowBackgroundBrush}" Topmost="True"
@@ -15,7 +16,7 @@
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Window.Resources>

--- a/ClassicAssist/UI/Views/GeneralControl.xaml
+++ b/ClassicAssist/UI/Views/GeneralControl.xaml
@@ -9,6 +9,7 @@
     xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
     xmlns:misc1="clr-namespace:ClassicAssist.UI.Misc"
     xmlns:behaviours="clr-namespace:ClassicAssist.UI.Misc.Behaviours"
+    xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
     x:Name="userControl"
     x:Class="ClassicAssist.UI.Views.GeneralControl"
     mc:Ignorable="d"
@@ -21,7 +22,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
         </ResourceDictionary>

--- a/ClassicAssist/UI/Views/Hotkeys/HotkeyOptionsWindow.xaml
+++ b/ClassicAssist/UI/Views/Hotkeys/HotkeyOptionsWindow.xaml
@@ -6,6 +6,7 @@
         xmlns:resources="clr-namespace:ClassicAssist.Shared.Resources;assembly=ClassicAssist.Shared"
         xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:behaviours="clr-namespace:ClassicAssist.Shared.UI.Behaviours;assembly=ClassicAssist.Shared"
+        xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
         mc:Ignorable="d"
         Title="{x:Static resources:Strings.Options}" SizeToContent="Height" Width="300"
         Background="{DynamicResource ThemeWindowBackgroundBrush}" Topmost="True"
@@ -13,7 +14,7 @@
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Window.Resources>

--- a/ClassicAssist/UI/Views/HotkeysTabControl.xaml
+++ b/ClassicAssist/UI/Views/HotkeysTabControl.xaml
@@ -11,6 +11,7 @@
              xmlns:valueConverters="clr-namespace:ClassicAssist.UI.Misc.ValueConverters"
              xmlns:sharedControls="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls"
              xmlns:commands="clr-namespace:ClassicAssist.Data.Hotkeys.Commands"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d"
              d:DesignHeight="300" d:DesignWidth="500">
     <UserControl.DataContext>
@@ -19,7 +20,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <valueConverters:InverseBooleanConverter x:Key="InverseBooleanConverter" />
             <CollectionViewSource x:Key='src' Source="{Binding FilterItems}">

--- a/ClassicAssist/UI/Views/HotkeysTabControl.xaml
+++ b/ClassicAssist/UI/Views/HotkeysTabControl.xaml
@@ -46,7 +46,10 @@
             </Grid.RowDefinitions>
             <sharedControls:FilterControl Grid.Row="0" FilterText="{Binding FilterText}" Margin="5,10,5,0" />
             <ListView Grid.Row="1" ItemsSource="{Binding Source={StaticResource src}}" Margin="5"
-                      PreviewMouseWheel="UIElement_OnPreviewMouseWheel">
+                      PreviewMouseWheel="UIElement_OnPreviewMouseWheel"
+                      VirtualizingPanel.IsVirtualizingWhenGrouping="True"
+                      VirtualizingPanel.ScrollUnit="Pixel"
+                      VirtualizingPanel.VirtualizationMode="Recycling">
                 <ListView.GroupStyle>
                     <GroupStyle>
                         <GroupStyle.ContainerStyle>
@@ -65,6 +68,7 @@
                                                 <Expander.Content>
                                                     <ListBox ItemsSource="{Binding Items/Children}" BorderThickness="0"
                                                              Margin="40,0,0,0"
+                                                             VirtualizingStackPanel.VirtualizationMode="Recycling"
                                                              SelectedItem="{Binding Path=Data.(viewModels:HotkeysTabViewModel.SelectedItem), Source={StaticResource Proxy}}">
                                                         <ListBox.ItemTemplate>
                                                             <DataTemplate DataType="commands:HotkeyCommand">

--- a/ClassicAssist/UI/Views/HuePickerWindow.xaml
+++ b/ClassicAssist/UI/Views/HuePickerWindow.xaml
@@ -7,13 +7,14 @@
         xmlns:resources="clr-namespace:ClassicAssist.Shared.Resources;assembly=ClassicAssist.Shared"
         xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:behaviours="clr-namespace:ClassicAssist.Shared.UI.Behaviours;assembly=ClassicAssist.Shared"
+        xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
         mc:Ignorable="d" Background="{DynamicResource ThemeWindowBackgroundBrush}"
         Title="{x:Static resources:Strings.Hue_Picker}" Height="350" Width="450"
         DataContext="{Binding Mode=OneWay, RelativeSource={RelativeSource Self}}">
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Window.Resources>

--- a/ClassicAssist/UI/Views/Macros/MacrosCodeTextEditor.xaml
+++ b/ClassicAssist/UI/Views/Macros/MacrosCodeTextEditor.xaml
@@ -8,12 +8,13 @@
              xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:behaviours="clr-namespace:ClassicAssist.UI.Misc.Behaviours"
              xmlns:valueConverters="clr-namespace:ClassicAssist.UI.Misc.ValueConverters"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary Source="../../../Resources/LeftRightIconToggleButton.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <valueConverters:LinePausedValueConverter x:Key="LinePausedValueConverter" />

--- a/ClassicAssist/UI/Views/Macros/MacrosCommandWindow.xaml
+++ b/ClassicAssist/UI/Views/Macros/MacrosCommandWindow.xaml
@@ -31,7 +31,10 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <Grid Grid.Row="0">
-            <ListView ItemsSource="{Binding Source={StaticResource src}}">
+            <ListView ItemsSource="{Binding Source={StaticResource src}}"
+                      VirtualizingPanel.IsVirtualizingWhenGrouping="True"
+                      VirtualizingPanel.ScrollUnit="Pixel"
+                      VirtualizingPanel.VirtualizationMode="Recycling">
                 <ListView.GroupStyle>
                     <GroupStyle>
                         <GroupStyle.ContainerStyle>
@@ -51,6 +54,7 @@
                                                 </Expander.Header>
                                                 <Expander.Content>
                                                     <ListBox ItemsSource="{Binding Items}" BorderThickness="0"
+                                                             VirtualizingStackPanel.VirtualizationMode="Recycling"
                                                              SelectedItem="{Binding DataContext.SelectedItem, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ListView}}}">
                                                         <ListBox.ItemTemplate>
                                                             <DataTemplate>

--- a/ClassicAssist/UI/Views/Macros/MacrosCommandWindow.xaml
+++ b/ClassicAssist/UI/Views/Macros/MacrosCommandWindow.xaml
@@ -7,6 +7,7 @@
         xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:macros="clr-namespace:ClassicAssist.UI.ViewModels.Macros"
         xmlns:behaviours="clr-namespace:ClassicAssist.Shared.UI.Behaviours;assembly=ClassicAssist.Shared"
+        xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
         mc:Ignorable="d" Background="{DynamicResource ThemeWindowBackgroundBrush}"
         Title="{x:Static resources:Strings.Commands}" Height="350" Width="400">
     <Window.DataContext>
@@ -15,7 +16,7 @@
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <CollectionViewSource x:Key='src' Source="{Binding Items}">
                 <CollectionViewSource.GroupDescriptions>

--- a/ClassicAssist/UI/Views/Macros/MacrosDebuggerControl.xaml
+++ b/ClassicAssist/UI/Views/Macros/MacrosDebuggerControl.xaml
@@ -7,11 +7,12 @@
              xmlns:valueConverters="clr-namespace:ClassicAssist.UI.Views.Macros.ValueConverters"
              xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:behaviours="clr-namespace:ClassicAssist.UI.Misc.Behaviours"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="500">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <DrawingImage x:Key="PlayIcon">
                 <DrawingImage.Drawing>

--- a/ClassicAssist/UI/Views/Macros/MacrosDebuggerControl.xaml.cs
+++ b/ClassicAssist/UI/Views/Macros/MacrosDebuggerControl.xaml.cs
@@ -17,11 +17,12 @@
 
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
-using System.Threading;
 using System.Threading.Tasks;
+using Assistant;
 using System.Windows;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
@@ -94,17 +95,13 @@ namespace ClassicAssist.UI.Views.Macros
                 return Task.CompletedTask;
             }
 
-            Thread t = new Thread( () =>
-                {
-                    ObjectInspectorWindow window =
-                        new ObjectInspectorWindow { DataContext = new ObjectInspectorViewModel( entity ) };
+            _ = Engine.Dispatcher.BeginInvoke( (Action) ( () =>
+            {
+                ObjectInspectorWindow window =
+                    new ObjectInspectorWindow { DataContext = new ObjectInspectorViewModel( entity ) };
 
-                    window.ShowDialog();
-                } )
-                { IsBackground = true };
-
-            t.SetApartmentState( ApartmentState.STA );
-            t.Start();
+                window.ShowDialog();
+            } ) );
 
             return Task.CompletedTask;
         }

--- a/ClassicAssist/UI/Views/MacrosTabControl.xaml
+++ b/ClassicAssist/UI/Views/MacrosTabControl.xaml
@@ -16,6 +16,7 @@
              xmlns:controls1="clr-namespace:ClassicAssist.UI.Controls"
              xmlns:behaviours="clr-namespace:ClassicAssist.Shared.UI.Behaviours;assembly=ClassicAssist.Shared"
              xmlns:macros="clr-namespace:ClassicAssist.UI.Views.Macros"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d"
              d:DesignHeight="500" Padding="5">
     <d:DesignerProperties.DesignStyle>
@@ -26,7 +27,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary Source="../../Resources/LeftRightIconToggleButton.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <valueConverters:InverseBooleanConverter x:Key="InverseBooleanConverter" />

--- a/ClassicAssist/UI/Views/MainWindow.xaml
+++ b/ClassicAssist/UI/Views/MainWindow.xaml
@@ -11,6 +11,7 @@
         xmlns:controls="clr-namespace:ClassicAssist.UI.Controls"
         xmlns:browser="clr-namespace:ClassicAssist.Browser"
         xmlns:behaviours="clr-namespace:ClassicAssist.UI.Misc.Behaviours"
+        xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
         mc:Ignorable="d"
         Height="500" Width="625" Topmost="{Binding CurrentOptions.AlwaysOnTop}"
         MinHeight="400" MinWidth="400"
@@ -30,7 +31,7 @@
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Window.Resources>

--- a/ClassicAssist/UI/Views/MultiClilocSelector.xaml
+++ b/ClassicAssist/UI/Views/MultiClilocSelector.xaml
@@ -8,11 +8,12 @@
              xmlns:controls="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls"
              xmlns:resources="clr-namespace:ClassicAssist.Shared.Resources;assembly=ClassicAssist.Shared"
              xmlns:valueConverters="clr-namespace:ClassicAssist.UI.Misc.ValueConverters"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d" d:DesignWidth="600">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <misc:BindingProxy x:Key="Proxy"
                                Data="{Binding Mode=OneWay, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MultiClilocSelector}}}" />

--- a/ClassicAssist/UI/Views/MultiItemIDSelector.xaml
+++ b/ClassicAssist/UI/Views/MultiItemIDSelector.xaml
@@ -6,11 +6,12 @@
              xmlns:local="clr-namespace:ClassicAssist.UI.Views"
              xmlns:controls="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls"
              xmlns:misc="clr-namespace:ClassicAssist.Misc"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d" d:DesignWidth="400">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <misc:BindingProxy x:Key="Proxy"
                                Data="{Binding Mode=OneWay, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type local:MultiItemIDSelector}}}" />

--- a/ClassicAssist/UI/Views/NewProfileWindow.xaml
+++ b/ClassicAssist/UI/Views/NewProfileWindow.xaml
@@ -9,13 +9,14 @@
     xmlns:resources="clr-namespace:ClassicAssist.Shared.Resources;assembly=ClassicAssist.Shared"
     xmlns:behaviours="clr-namespace:ClassicAssist.Shared.UI.Behaviours;assembly=ClassicAssist.Shared"
     xmlns:System="clr-namespace:System;assembly=mscorlib"
+    xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
     x:Class="ClassicAssist.UI.Views.NewProfileWindow"
     mc:Ignorable="d" Background="{DynamicResource ThemeWindowBackgroundBrush}"
     Title="{x:Static resources:Strings.New_Profile}" SizeToContent="Height" Width="350" WindowStyle="ToolWindow" WindowStartupLocation="CenterOwner">
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <ValueConverters:EnumMatchToBooleanConverter x:Key="EnumMatchToBooleanConverter" />
             <viewModels:NewProfileViewModel x:Key="DummyData">

--- a/ClassicAssist/UI/Views/ObjectInpectorWindow.xaml
+++ b/ClassicAssist/UI/Views/ObjectInpectorWindow.xaml
@@ -8,6 +8,7 @@
         xmlns:resources="clr-namespace:ClassicAssist.Shared.Resources;assembly=ClassicAssist.Shared"
         xmlns:models="clr-namespace:ClassicAssist.UI.Models"
         xmlns:behaviours="clr-namespace:ClassicAssist.UI.Misc.Behaviours"
+        xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
         mc:Ignorable="d" Topmost="True"
         Title="{x:Static resources:Strings.Object_Inspector}" Height="396.8" Width="450">
     <Window.InputBindings>
@@ -19,7 +20,7 @@
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <viewModels:ObjectInspectorViewModel x:Key="DummyData">
                 <viewModels:ObjectInspectorViewModel.Items>

--- a/ClassicAssist/UI/Views/OptionsTab/MacrosGumpControl.xaml
+++ b/ClassicAssist/UI/Views/OptionsTab/MacrosGumpControl.xaml
@@ -5,11 +5,12 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:resources="clr-namespace:ClassicAssist.Shared.Resources;assembly=ClassicAssist.Shared"
              xmlns:viewModels="clr-namespace:ClassicAssist.UI.ViewModels"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d" d:DataContext="{d:DesignInstance viewModels:OptionsTabViewModel}">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>

--- a/ClassicAssist/UI/Views/OptionsTab/MacrosGumpTextColorSelectorWindow.xaml
+++ b/ClassicAssist/UI/Views/OptionsTab/MacrosGumpTextColorSelectorWindow.xaml
@@ -8,12 +8,13 @@
         xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:behaviours="clr-namespace:ClassicAssist.Shared.UI.Behaviours;assembly=ClassicAssist.Shared"
         xmlns:optionsTab="clr-namespace:ClassicAssist.UI.Views.OptionsTab"
+        xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
         mc:Ignorable="d" Background="{DynamicResource ThemeWindowBackgroundBrush}"
         Title="{x:Static resources:Strings.Text_Color}" SizeToContent="WidthAndHeight" Topmost="True">
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Window.Resources>

--- a/ClassicAssist/UI/Views/OptionsTab/QueueLastTargetControl.xaml
+++ b/ClassicAssist/UI/Views/OptionsTab/QueueLastTargetControl.xaml
@@ -6,11 +6,12 @@
              xmlns:resources="clr-namespace:ClassicAssist.Shared.Resources;assembly=ClassicAssist.Shared"
              xmlns:viewModels="clr-namespace:ClassicAssist.UI.ViewModels"
              xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d" d:DataContext="{d:DesignInstance viewModels:OptionsTabViewModel}">
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>

--- a/ClassicAssist/UI/Views/OptionsTabControl.xaml
+++ b/ClassicAssist/UI/Views/OptionsTabControl.xaml
@@ -13,6 +13,7 @@
     xmlns:controls="clr-namespace:ClassicAssist.Controls;assembly=ClassicAssist.Controls"
     xmlns:optionsTab="clr-namespace:ClassicAssist.UI.Views.OptionsTab"
     xmlns:behaviours="clr-namespace:ClassicAssist.UI.Misc.Behaviours"
+    xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
     x:Class="ClassicAssist.UI.Views.OptionsTabControl"
     mc:Ignorable="d"
     d:DesignHeight="633.233" d:DesignWidth="798.666">
@@ -24,7 +25,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>

--- a/ClassicAssist/UI/Views/RepositionableGumpWindow.xaml
+++ b/ClassicAssist/UI/Views/RepositionableGumpWindow.xaml
@@ -6,6 +6,7 @@
         xmlns:viewModels="clr-namespace:ClassicAssist.UI.ViewModels"
         xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:behaviours="clr-namespace:ClassicAssist.Shared.UI.Behaviours;assembly=ClassicAssist.Shared"
+        xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
         mc:Ignorable="d" WindowStartupLocation="CenterScreen" Opacity="0.5" WindowStyle="None"
         AllowsTransparency="True" Topmost="True"
         Title="Position" Height="130" Width="200" Background="{DynamicResource ThemeWindowBackgroundBrush}"
@@ -16,7 +17,7 @@
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../Resources/DarkTheme.xaml" />
                 <ResourceDictionary>
                     <DrawingImage x:Key="TickIcon">
                         <DrawingImage.Drawing>

--- a/ClassicAssist/UI/Views/SingleHuePicker.xaml
+++ b/ClassicAssist/UI/Views/SingleHuePicker.xaml
@@ -7,13 +7,14 @@
         xmlns:resources="clr-namespace:ClassicAssist.Shared.Resources;assembly=ClassicAssist.Shared"
         xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:behaviours="clr-namespace:ClassicAssist.Shared.UI.Behaviours;assembly=ClassicAssist.Shared"
+        xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
         mc:Ignorable="d" Background="{DynamicResource ThemeWindowBackgroundBrush}"
         Title="{x:Static resources:Strings.Hue_Picker}" Height="350" Width="450"
         DataContext="{Binding Mode=OneWay, RelativeSource={RelativeSource Self}}">
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Window.Resources>

--- a/ClassicAssist/UI/Views/SkillsTabControl.xaml
+++ b/ClassicAssist/UI/Views/SkillsTabControl.xaml
@@ -13,6 +13,7 @@
              xmlns:skills="clr-namespace:ClassicAssist.Data.Skills"
              xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:behaviours="clr-namespace:ClassicAssist.UI.Misc.Behaviours"
+             xmlns:shared="clr-namespace:ClassicAssist.Shared.UI;assembly=ClassicAssist.Shared"
              mc:Ignorable="d">
     <d:DesignerProperties.DesignStyle>
         <Style TargetType="UserControl">
@@ -25,7 +26,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="../../Resources/DarkTheme.xaml" />
+                <shared:SharedResourceDictionary Source="../../Resources/DarkTheme.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>

--- a/ClassicAssist/UO/Gumps/RepositionableGump.cs
+++ b/ClassicAssist/UO/Gumps/RepositionableGump.cs
@@ -17,8 +17,8 @@
 
 #endregion
 
+using System;
 using System.Collections.Generic;
-using System.Threading;
 using System.Windows.Interop;
 using Assistant;
 using ClassicAssist.UI.ViewModels;
@@ -62,21 +62,15 @@ namespace ClassicAssist.UO.Gumps
         {
             if ( buttonID == REPOSITION_BUTTON_ID )
             {
-                Engine.Dispatcher.Invoke( () =>
+                _ = Engine.Dispatcher.BeginInvoke( (Action) ( () =>
                 {
-                    Thread t = new Thread( () =>
-                    {
-                        SetPosition( GumpX, GumpY );
-                        RepositionableGumpViewModel vm = new RepositionableGumpViewModel( this, GumpX, GumpY );
-                        RepositionableGumpWindow window = new RepositionableGumpWindow { DataContext = vm };
-                        WindowInteropHelper helper = new WindowInteropHelper( window ) { Owner = Engine.WindowHandle };
-                        window.ShowInTaskbar = false;
-                        window.ShowDialog();
-                    } ) { IsBackground = true };
-
-                    t.SetApartmentState( ApartmentState.STA );
-                    t.Start();
-                } );
+                    SetPosition( GumpX, GumpY );
+                    RepositionableGumpViewModel vm = new RepositionableGumpViewModel( this, GumpX, GumpY );
+                    RepositionableGumpWindow window = new RepositionableGumpWindow { DataContext = vm };
+                    WindowInteropHelper helper = new WindowInteropHelper( window ) { Owner = Engine.WindowHandle };
+                    window.ShowInTaskbar = false;
+                    window.ShowDialog();
+                } ) );
             }
 
             base.OnResponse( buttonID, switches, textEntries );


### PR DESCRIPTION
## Summary

WPF performance improvements focused on reducing per-view resource cost and enabling UI virtualization.

## Changes

- **`SharedResourceDictionary`** — new type that caches parsed `ResourceDictionary` instances (notably `DarkTheme.xaml`) so the theme is parsed once and shared across ~91 views instead of being re-parsed per view. Applied across all views/windows and the Launcher/Updater `App.xaml`.
- **STA thread window fixes** — resolve remaining crashes when windows using `SharedResourceDictionary` are created off the main dispatcher (chat window, GIF capture, macro debugger, repositionable gump, main commands).
- **Reduced resource-lookup overhead** — trim redundant dynamic-resource lookups in completion/title controls and several agent tabs; also fixes a hotkey UI binding bug.
- **UI virtualization** — enable virtualization in the chat, hotkeys, and macro command list views for smoother scrolling with large lists.

## Notes

Cherry-picked from a larger feature branch as a self-contained set. Builds clean (ClassicAssist, Launcher, Updater).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved chat message rendering with smoother scrolling and virtualisation.
  - Added more efficient list handling in hotkeys and macro views.
  - Standardised dark-theme resource loading across the application.

- **Bug Fixes**
  - Improved responsiveness when opening chat, capture, inspector and repositioning windows.
  - Hotkey displays now refresh correctly after clearing shortcuts.
  - Corrected list binding behaviour in several agent views.

- **Performance**
  - Reduced repeated theme resource loading and improved UI list performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->