### PR TITLE
Object Inspector and agent view-model correctness fixes

### DIFF
--- a/ClassicAssist/UI/ViewModels/Agents/AutolootViewModel.cs
+++ b/ClassicAssist/UI/ViewModels/Agents/AutolootViewModel.cs
@@ -463,6 +463,11 @@ namespace ClassicAssist.UI.ViewModels.Agents
 
         private void ClipboardPaste( object obj )
         {
+            if ( SelectedItem == null )
+            {
+                return;
+            }
+
             string text = Clipboard.GetText();
 
             try
@@ -478,7 +483,7 @@ namespace ClassicAssist.UI.ViewModels.Agents
                 {
                     if ( !SelectedItem.Constraints.Contains( entry ) )
                     {
-                        SelectedItem?.Constraints.Add( entry );
+                        SelectedItem.Constraints.Add( entry );
                     }
                 }
             }
@@ -495,9 +500,16 @@ namespace ClassicAssist.UI.ViewModels.Agents
                 return;
             }
 
-            string text = JsonConvert.SerializeObject( entries );
+            try
+            {
+                string text = JsonConvert.SerializeObject( entries );
 
-            Clipboard.SetText( text );
+                Clipboard.SetText( text );
+            }
+            catch ( Exception )
+            {
+                // ignored
+            }
         }
 
         internal void OnCorpseEvent( int serial, bool force = false )

--- a/ClassicAssist/UI/ViewModels/Agents/DressTabViewModel.cs
+++ b/ClassicAssist/UI/ViewModels/Agents/DressTabViewModel.cs
@@ -345,7 +345,7 @@ namespace ClassicAssist.UI.ViewModels.Agents
                 return;
             }
 
-            if ( !SelectedItem.Items.Contains( removeItem ) )
+            if ( SelectedItem == null || !SelectedItem.Items.Contains( removeItem ) )
             {
                 return;
             }
@@ -363,6 +363,11 @@ namespace ClassicAssist.UI.ViewModels.Agents
             }
 
             int serial = await Commands.GetTargetSerialAsync( Strings.Target_clothing_item___ );
+
+            if ( serial <= 0 )
+            {
+                return;
+            }
 
             Item item = Engine.Items.GetItem( serial );
 

--- a/ClassicAssist/UI/ViewModels/ObjectInspectorViewModel.cs
+++ b/ClassicAssist/UI/ViewModels/ObjectInspectorViewModel.cs
@@ -415,15 +415,11 @@ namespace ClassicAssist.UI.ViewModels
 
         private static void ShowProperties( IEnumerable<Property> properties )
         {
-            Thread t = new Thread( () =>
+            _ = Engine.Dispatcher.BeginInvoke( (Action) ( () =>
             {
                 DebugWindow window = new DebugWindow( typeof(DebugPropertiesViewModel), properties ) { Topmost = true };
                 window.Show();
-                Dispatcher.Run();
-            } ) { IsBackground = true };
-
-            t.SetApartmentState( ApartmentState.STA );
-            t.Start();
+            } ) );
         }
 
         private static void InspectObject( int serial )

--- a/ClassicAssist/UI/ViewModels/ObjectInspectorViewModel.cs
+++ b/ClassicAssist/UI/ViewModels/ObjectInspectorViewModel.cs
@@ -113,7 +113,7 @@ namespace ClassicAssist.UI.ViewModels
             {
                 float health = mobile.Hits;
                 float maxHealth = mobile.HitsMax;
-                float per = health / maxHealth * 100;
+                float per = maxHealth > 0 ? health / maxHealth * 100 : 0;
                 AddData( "Hits", ( (uint) per ).ToString() + '%', Strings.Mobile );
             }
 
@@ -355,13 +355,25 @@ namespace ClassicAssist.UI.ViewModels
 
             foreach ( PropertyInfo p in properties )
             {
-                object value = p.GetValue( entity );
-                string valueString = "null";
-
-                if ( value != null )
+                // Indexers throw when GetValue is called without index arguments.
+                if ( p.GetIndexParameters().Length > 0 )
                 {
-                    valueString = value.ToString();
+                    continue;
                 }
+
+                object value;
+
+                try
+                {
+                    value = p.GetValue( entity );
+                }
+                catch ( Exception )
+                {
+                    // A single throwing getter shouldn't abort the whole inspector.
+                    continue;
+                }
+
+                string valueString = value?.ToString() ?? "null";
 
                 DisplayFormatAttribute attr = entity.GetType().GetPropertyAttribute<DisplayFormatAttribute>( p.Name );
 

--- a/ClassicAssist/UI/ViewModels/SkillsTabViewModel.cs
+++ b/ClassicAssist/UI/ViewModels/SkillsTabViewModel.cs
@@ -262,7 +262,7 @@ namespace ClassicAssist.UI.ViewModels
 
         private void SetAllSkillLocks( object obj )
         {
-            LockStatus lockStatus = (LockStatus) (int) obj;
+            LockStatus lockStatus = (LockStatus) obj;
 
             IEnumerable<SkillEntry> skillsToSet = Items.Where( i => i.LockStatus != lockStatus );
 
@@ -271,7 +271,10 @@ namespace ClassicAssist.UI.ViewModels
                 Commands.ChangeSkillLock( skillEntry, lockStatus, false );
             }
 
-            Commands.MobileQuery( Engine.Player.Serial, MobileQueryType.SkillsRequest );
+            if ( Engine.Player != null )
+            {
+                Commands.MobileQuery( Engine.Player.Serial, MobileQueryType.SkillsRequest );
+            }
         }
 
         private void UpdateTotalBase()

--- a/ClassicAssist/UI/Views/ObjectInspectorWindow.xaml
+++ b/ClassicAssist/UI/Views/ObjectInspectorWindow.xaml
@@ -14,9 +14,6 @@
     <Window.InputBindings>
         <KeyBinding Modifiers="Ctrl" Key="C" Command="{Binding CopyToClipboardCommand}" />
     </Window.InputBindings>
-    <Window.DataContext>
-        <viewModels:ObjectInspectorViewModel />
-    </Window.DataContext>
     <Window.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/ClassicAssist/UI/Views/ObjectInspectorWindow.xaml.cs
+++ b/ClassicAssist/UI/Views/ObjectInspectorWindow.xaml.cs
@@ -3,7 +3,7 @@
 namespace ClassicAssist.UI.Views
 {
     /// <summary>
-    ///     Interaction logic for ObjectInpectorWindow.xaml
+    ///     Interaction logic for ObjectInspectorWindow.xaml
     /// </summary>
     public partial class ObjectInspectorWindow : Window
     {

--- a/ClassicAssist/UI/Views/SkillsTabControl.xaml
+++ b/ClassicAssist/UI/Views/SkillsTabControl.xaml
@@ -110,7 +110,7 @@
                       Margin="0,5,0,0" SelectedIndex="0" />
             <Button Content="{x:Static sharedResources:Strings.Set}"
                     Command="{Binding SetAllSkillLocksCommand, Mode=OneWay}"
-                    CommandParameter="{Binding SelectedIndex, ElementName=comboBox}" />
+                    CommandParameter="{Binding SelectedItem, ElementName=comboBox}" />
             <TextBlock Text="{x:Static sharedResources:Strings.Total_base_}" Margin="0,30,0,0" TextWrapping="Wrap" />
             <TextBlock Text="{Binding TotalBase}" FontWeight="Bold" Margin="0,3,0,0" />
         </StackPanel>

--- a/ClassicAssist/UO/Commands.cs
+++ b/ClassicAssist/UO/Commands.cs
@@ -1020,16 +1020,13 @@ namespace ClassicAssist.UO
                     return;
                 }
 
-                Thread t = new Thread( () =>
+                _ = Engine.Dispatcher.BeginInvoke( (Action) ( () =>
                 {
                     ObjectInspectorWindow window =
                         new ObjectInspectorWindow { DataContext = new ObjectInspectorViewModel( entity ) };
 
                     window.ShowDialog();
-                } ) { IsBackground = true };
-
-                t.SetApartmentState( ApartmentState.STA );
-                t.Start();
+                } ) );
             }
             else
             {
@@ -1041,7 +1038,7 @@ namespace ClassicAssist.UO
                     }
 
                     LandTile landTile = MapInfo.GetLandTile( (int) Engine.Player.Map, x, y );
-                    Thread t = new Thread( () =>
+                    _ = Engine.Dispatcher.BeginInvoke( (Action) ( () =>
                     {
                         ObjectInspectorWindow window = new ObjectInspectorWindow
                         {
@@ -1049,10 +1046,7 @@ namespace ClassicAssist.UO
                         };
 
                         window.ShowDialog();
-                    } ) { IsBackground = true };
-
-                    t.SetApartmentState( ApartmentState.STA );
-                    t.Start();
+                    } ) );
                 }
                 else
                 {
@@ -1068,7 +1062,7 @@ namespace ClassicAssist.UO
                         selectedStatic.Z = z;
                     }
 
-                    Thread t = new Thread( () =>
+                    _ = Engine.Dispatcher.BeginInvoke( (Action) ( () =>
                     {
                         ObjectInspectorWindow window = new ObjectInspectorWindow
                         {
@@ -1076,10 +1070,7 @@ namespace ClassicAssist.UO
                         };
 
                         window.ShowDialog();
-                    } ) { IsBackground = true };
-
-                    t.SetApartmentState( ApartmentState.STA );
-                    t.Start();
+                    } ) );
                 }
             }
         }


### PR DESCRIPTION
## Summary

Crash and correctness fixes for the Object Inspector and several agent view models.

## Changes

**Object Inspector**
- Fix crash when opened via hotkey.
- Fix `DebugWindow` crash in `ObjectInspectorViewModel.ShowProperties`.
- `AddPublicProperties`: skip indexer properties and guard `GetValue` in try/catch so one throwing/indexed getter no longer aborts the whole inspector.
- `AddMobileProperties`: guard the `HitsMax == 0` division (was `NaN`/garbage %).
- Rename `ObjectInpectorWindow` → `ObjectInspectorWindow` (file spelling) and drop the dead runtime `Window.DataContext`.

**Skills**
- Null-check `Engine.Player` before `MobileQuery` (NRE when disconnected).
- Pass the ComboBox `SelectedItem` (the `LockStatus` value) instead of `SelectedIndex`, removing a fragile index→enum cast.

**Autoloot**
- `ClipboardPaste`: guard `SelectedItem == null` (was an NRE swallowed by the catch, silently no-oping).
- `ClipboardCopy`: wrap `Clipboard.SetText` in try/catch.

**Dress**
- `RemoveDressItem`: guard `SelectedItem == null` (the command checked `SelectedDressItem` but the method dereferenced `SelectedItem`).
- `AddDressItem`: return on `serial <= 0` to avoid a spurious "cannot find item" message when the target is cancelled.

## Notes

Cherry-picked from a larger feature branch. Builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
