### PR TITLE
Add DropItemToGround macro command with server-accurate fit validation

### DIFF
--- a/ClassicAssist/Data/Macros/Commands/ObjectCommands.cs
+++ b/ClassicAssist/Data/Macros/Commands/ObjectCommands.cs
@@ -388,6 +388,65 @@ namespace ClassicAssist.Data.Macros.Commands
         }
 
         [CommandsDisplay( Category = nameof( Strings.Entity ),
+            Parameters = new[] { nameof( ParameterType.SerialOrAlias ), nameof( ParameterType.Amount ) } )]
+        public static bool DropItemToGround( object item, int amount = -1 )
+        {
+            int itemSerial = AliasCommands.ResolveSerial( item, false );
+
+            if ( itemSerial == 0 )
+            {
+                UOC.SystemMessage( Strings.Invalid_or_unknown_object_id, true );
+
+                return false;
+            }
+
+            Item itemObj = Engine.Items.GetItem( itemSerial );
+
+            if ( itemObj == null )
+            {
+                UOC.SystemMessage( Strings.Invalid_or_unknown_object_id, true );
+
+                return false;
+            }
+
+            PlayerMobile player = Engine.Player;
+
+            if ( player == null )
+            {
+                return false;
+            }
+
+            if ( amount == -1 )
+            {
+                amount = itemObj.Count;
+            }
+
+            int map = (int) player.Map;
+
+            // 8 adjacent tiles, clockwise from north: N, NE, E, SE, S, SW, W, NW.
+            int[][] offsets =
+            {
+                new[] { 0, -1 }, new[] { 1, -1 }, new[] { 1, 0 }, new[] { 1, 1 }, new[] { 0, 1 }, new[] { -1, 1 },
+                new[] { -1, 0 }, new[] { -1, -1 }
+            };
+
+            foreach ( int[] offset in offsets )
+            {
+                int tx = player.X + offset[0];
+                int ty = player.Y + offset[1];
+
+                if ( MapInfo.ItemCanFit( map, tx, ty, itemObj.ID, out int dropZ ) )
+                {
+                    ActionPacketQueue.EnqueueDragDropGround( itemSerial, amount, tx, ty, dropZ );
+
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        [CommandsDisplay( Category = nameof( Strings.Entity ),
             Parameters = new[]
             {
                 nameof( ParameterType.SerialOrAlias ), nameof( ParameterType.XCoordinateOffset ),

--- a/ClassicAssist/Resources/MacroCommandHelp.resx
+++ b/ClassicAssist/Resources/MacroCommandHelp.resx
@@ -1924,6 +1924,12 @@ if FindType(0xe79, -1, 'backpack'):
   <data name="UNSETPLAYERALIAS_COMMAND_INSERTTEXT" xml:space="preserve">
     <value>UnsetPlayerAlias("mount")</value>
   </data>
+  <data name="DROPITEMTOGROUND_COMMAND_DESCRIPTION" xml:space="preserve">
+    <value>Drops the specified serial/alias onto the first of the 8 tiles adjacent to the player where it will fit, no amount specified or -1 will drop the full stack. Returns true if the item was dropped.</value>
+  </data>
+  <data name="DROPITEMTOGROUND_COMMAND_INSERTTEXT" xml:space="preserve">
+    <value>DropItemToGround('found', -1)</value>
+  </data>
   <data name="MOVEITEMXYZ_COMMAND_DESCRIPTION" xml:space="preserve">
     <value>Moves the specified serial/alias to the given coordinates</value>
   </data>

--- a/ClassicAssist/UO/Data/LandTile.cs
+++ b/ClassicAssist/UO/Data/LandTile.cs
@@ -8,5 +8,11 @@
         public int X { get; set; }
         public int Y { get; set; }
         public sbyte Z { get; set; }
+
+        /// <summary>
+        ///     Void / no-draw land tiles that represent "nothing" and should not be treated as
+        ///     real terrain (e.g. for surface / line of sight calculations).
+        /// </summary>
+        public bool Ignored => ID == 2 || ID == 0x1DB || ( ID >= 0x1AE && ID <= 0x1B5 );
     }
 }

--- a/ClassicAssist/UO/Data/Map.cs
+++ b/ClassicAssist/UO/Data/Map.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Assistant;
+using ClassicAssist.UO.Objects;
 
 namespace ClassicAssist.UO.Data
 {
@@ -102,6 +104,343 @@ namespace ClassicAssist.UO.Data
             }
 
             return ( staticTile.Z + staticTile.Height, staticTile.ID );
+        }
+
+        public static int GetAverageZ( int map, int x, int y )
+        {
+            GetAverageZ( map, x, y, out _, out int avg, out _ );
+
+            return avg;
+        }
+
+        public static void GetAverageZ( int map, int x, int y, out int z, out int avg, out int top )
+        {
+            int zTop = GetLandTile( map, x, y ).Z;
+            int zLeft = GetLandTile( map, x, y + 1 ).Z;
+            int zRight = GetLandTile( map, x + 1, y ).Z;
+            int zBottom = GetLandTile( map, x + 1, y + 1 ).Z;
+
+            z = zTop;
+
+            if ( zLeft < z )
+            {
+                z = zLeft;
+            }
+
+            if ( zRight < z )
+            {
+                z = zRight;
+            }
+
+            if ( zBottom < z )
+            {
+                z = zBottom;
+            }
+
+            top = zTop;
+
+            if ( zLeft > top )
+            {
+                top = zLeft;
+            }
+
+            if ( zRight > top )
+            {
+                top = zRight;
+            }
+
+            if ( zBottom > top )
+            {
+                top = zBottom;
+            }
+
+            avg = Math.Abs( zTop - zBottom ) > Math.Abs( zLeft - zRight )
+                ? FloorAverage( zLeft, zRight )
+                : FloorAverage( zTop, zBottom );
+        }
+
+        private static int FloorAverage( int a, int b )
+        {
+            int v = a + b;
+
+            if ( v < 0 )
+            {
+                --v;
+            }
+
+            return v / 2;
+        }
+
+        public static bool InRange( int p1X, int p1Y, int p2X, int p2Y, int range )
+        {
+            return p1X >= p2X - range && p1X <= p2X + range && p1Y >= p2Y - range && p1Y <= p2Y + range;
+        }
+
+        private static void GetItemsAtLocation( int x, int y, List<Item> results )
+        {
+            foreach ( Item item in Engine.Items )
+            {
+                if ( item.X == x && item.Y == y )
+                {
+                    results.Add( item );
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Determines whether an item of the given art id will fit on the ground at ( x, y ) using
+        ///     the ModernUO Item.DropToWorld fit/stack algorithm, from the player's location. Returns the
+        ///     resolved drop Z via <paramref name="dropZ" />. NOTE: the line of sight check performed by
+        ///     the server is intentionally omitted here.
+        /// </summary>
+        public static bool ItemCanFit( int map, int x, int y, int itemId, out int dropZ )
+        {
+            dropZ = 0;
+
+            if ( Engine.Player == null )
+            {
+                return false;
+            }
+
+            return ItemCanFit( map, x, y, itemId, Engine.Player.X, Engine.Player.Y, Engine.Player.Z, out dropZ );
+        }
+
+        public static bool ItemCanFit( int map, int x, int y, int itemId, int fromX, int fromY, int fromZ,
+            out int dropZ )
+        {
+            dropZ = 0;
+
+            if ( x < 0 || y < 0 )
+            {
+                return false;
+            }
+
+            if ( !InRange( fromX, fromY, x, y, 2 ) )
+            {
+                return false;
+            }
+
+            int maxZ = fromZ + 16;
+
+            LandTile landTile = GetLandTile( map, x, y );
+            GetAverageZ( map, x, y, out int landZ, out int landAvg, out _ );
+            TileFlags landFlags = landTile.Flags;
+            bool landImpassable = ( landFlags & TileFlags.Impassable ) != 0;
+
+            int z = int.MinValue;
+
+            // Passable, non-ignored land counts as a base surface.
+            if ( !landTile.Ignored && !landImpassable && landAvg <= maxZ )
+            {
+                z = landAvg;
+            }
+
+            StaticTile[] statics = Statics.GetStatics( map, x, y ) ?? Array.Empty<StaticTile>();
+
+            foreach ( StaticTile tile in statics )
+            {
+                if ( !tile.Flags.HasFlag( TileFlags.Surface ) )
+                {
+                    continue;
+                }
+
+                int calcHeight = tile.Flags.HasFlag( TileFlags.Bridge ) ? tile.Height / 2 : tile.Height;
+                int top = tile.Z + calcHeight;
+
+                if ( top > maxZ || top < z )
+                {
+                    continue;
+                }
+
+                z = top;
+            }
+
+            List<Item> items = new List<Item>();
+            GetItemsAtLocation( x, y, items );
+
+            foreach ( Item item in items )
+            {
+                StaticTile idata = TileData.GetStaticTile( item.ID );
+
+                if ( !idata.Flags.HasFlag( TileFlags.Surface ) )
+                {
+                    continue;
+                }
+
+                int calcHeight = idata.Flags.HasFlag( TileFlags.Bridge ) ? idata.Height / 2 : idata.Height;
+                int top = item.Z + calcHeight;
+
+                if ( top <= maxZ && top >= z )
+                {
+                    z = top;
+                }
+            }
+
+            if ( z == int.MinValue || z > maxZ )
+            {
+                return false;
+            }
+
+            int surfaceZ = z;
+
+            // 20-bit vertical occupancy mask for the space directly above the surface.
+            int openSlots = ( 1 << 20 ) - 1;
+
+            foreach ( StaticTile tile in statics )
+            {
+                int calcHeight = tile.Flags.HasFlag( TileFlags.Bridge ) ? tile.Height / 2 : tile.Height;
+                int checkZ = tile.Z;
+                int checkTop = checkZ + calcHeight;
+
+                if ( checkTop == checkZ && !tile.Flags.HasFlag( TileFlags.Surface ) )
+                {
+                    ++checkTop;
+                }
+
+                int zStart = Math.Max( checkZ - z, 0 );
+                int zEnd = Math.Min( checkTop - z, 19 );
+
+                if ( zStart >= 20 || zEnd < 0 )
+                {
+                    continue;
+                }
+
+                int bitCount = zEnd - zStart;
+                openSlots &= ~( ( ( 1 << bitCount ) - 1 ) << zStart );
+            }
+
+            foreach ( Item item in items )
+            {
+                StaticTile idata = TileData.GetStaticTile( item.ID );
+                int calcHeight = idata.Flags.HasFlag( TileFlags.Bridge ) ? idata.Height / 2 : idata.Height;
+                int checkZ = item.Z;
+                int checkTop = checkZ + calcHeight;
+
+                if ( checkTop == checkZ && !idata.Flags.HasFlag( TileFlags.Surface ) )
+                {
+                    ++checkTop;
+                }
+
+                int zStart = Math.Max( checkZ - z, 0 );
+                int zEnd = Math.Min( checkTop - z, 19 );
+
+                if ( zStart >= 20 || zEnd < 0 )
+                {
+                    continue;
+                }
+
+                int bitCount = zEnd - zStart;
+                openSlots &= ~( ( ( 1 << bitCount ) - 1 ) << zStart );
+            }
+
+            StaticTile itemData = TileData.GetStaticTile( itemId );
+            int height = itemData.Height;
+
+            if ( height == 0 )
+            {
+                ++height;
+            }
+
+            if ( height > 30 )
+            {
+                height = 30;
+            }
+
+            int match = ( 1 << height ) - 1;
+            bool okay = false;
+
+            for ( int i = 0; i < 20; ++i )
+            {
+                if ( i + height > 20 )
+                {
+                    match >>= 1;
+                }
+
+                okay = ( ( openSlots >> i ) & match ) == match;
+
+                if ( okay )
+                {
+                    z += i;
+
+                    break;
+                }
+            }
+
+            if ( !okay )
+            {
+                return false;
+            }
+
+            // The resolved drop height must stay within reach of the origin. When the only gap
+            // sits on top of a full stack ( e.g. z = 17 above a stack topping out at 16 ) the
+            // server refuses the drop, so reject the tile and let the caller try another one.
+            if ( z > maxZ )
+            {
+                return false;
+            }
+
+            height = itemData.Height;
+
+            if ( height == 0 )
+            {
+                ++height;
+            }
+
+            // Final intersection re-checks (server post-placement validation).
+            if ( landAvg > z && z + height > landZ )
+            {
+                return false;
+            }
+
+            if ( landImpassable && landAvg > surfaceZ && z + height > landZ )
+            {
+                return false;
+            }
+
+            foreach ( StaticTile tile in statics )
+            {
+                bool surface = tile.Flags.HasFlag( TileFlags.Surface );
+                bool impassable = tile.Flags.HasFlag( TileFlags.Impassable );
+                int calcHeight = tile.Flags.HasFlag( TileFlags.Bridge ) ? tile.Height / 2 : tile.Height;
+                int checkZ = tile.Z;
+                int checkTop = checkZ + calcHeight;
+
+                if ( checkTop > z && z + height > checkZ )
+                {
+                    return false;
+                }
+
+                if ( ( surface || impassable ) && checkTop > surfaceZ && z + height > checkZ )
+                {
+                    return false;
+                }
+            }
+
+            foreach ( Item item in items )
+            {
+                StaticTile idata = TileData.GetStaticTile( item.ID );
+                int calcHeight = idata.Flags.HasFlag( TileFlags.Bridge ) ? idata.Height / 2 : idata.Height;
+
+                if ( item.Z + calcHeight > z && z + height > item.Z )
+                {
+                    return false;
+                }
+            }
+
+            // An item cannot be dropped on a tile occupied by a mobile.
+            foreach ( Mobile mobile in Engine.Mobiles )
+            {
+                if ( mobile.X == x && mobile.Y == y && mobile.Z + 16 > z && z + height > mobile.Z )
+                {
+                    return false;
+                }
+            }
+
+            // NOTE: the server also performs a line of sight check here; intentionally omitted.
+
+            dropZ = z;
+
+            return true;
         }
 
         private static string GetMapFilename( int map )


### PR DESCRIPTION
## Summary

Add a `DropItemToGround` macro command backed by a server-accurate ground-fit validation.

## Changes

- **`MapInfo.ItemCanFit`** (`Map.cs`) — a port of ModernUO's `Item.DropToWorld` fit/stack algorithm: selects a base surface Z bounded by the origin, builds a 20-bit vertical occupancy mask above the surface, finds the lowest gap tall enough for the item, runs the final intersection re-checks, and rejects tiles occupied by a mobile. Includes supporting helpers (`GetAverageZ`, `InRange`) and a `LandTile.Ignored` helper.
- **`ObjectCommands.DropItemToGround`** — macro command that scans the 8 tiles adjacent to the player (N..NW) and drops the item on the first tile that fits, returning `bool`.
- Macro help text for the new command.

## Notes

Extracted from a larger feature branch. The related Entity Collection Viewer "Drop to ground" context-menu button was intentionally left out here because it depends on other (as-yet-unmerged) ECV work; this PR is just the self-contained macro command + fit validation. Builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
