### PR TITLE
Launcher: shut down ClassicUO cleanly on exit

### DIFF
--- a/ClassicAssist.Launcher/MainViewModel.cs
+++ b/ClassicAssist.Launcher/MainViewModel.cs
@@ -536,6 +536,7 @@ namespace ClassicAssist.Launcher
 
             if ( p != null && !p.HasExited )
             {
+                Closing( null );
                 Application.Current.Shutdown( 0 );
             }
         }


### PR DESCRIPTION
Ensure the launched ClassicUO process is shut down cleanly when the launcher exits, rather than being left running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)