### PR TITLE
Fix object/QuestPointer removal and add damageable object / multi handling

### DIFF
--- a/ClassicAssist/Data/Macros/Commands/TargetCommands.cs
+++ b/ClassicAssist/Data/Macros/Commands/TargetCommands.cs
@@ -138,7 +138,25 @@ namespace ClassicAssist.Data.Macros.Commands
                 }
             }
 
-            Engine.SendPacketToServer( new Target( TargetTypeEnum.Object, senderSerial, TargetFlags.None, serial, -1, -1, -1, 0,
+            int x = -1;
+            int y = -1;
+            int z = -1;
+            int id = 0;
+
+            if ( Engine.TargetType == TargetTypeEnum.Tile )
+            {
+                Entity entity = UOMath.IsMobile( serial ) ? (Entity) Engine.Mobiles.GetMobile( serial ) : Engine.Items.GetItem( serial );
+
+                if ( entity != null )
+                {
+                    x = entity.X;
+                    y = entity.Y;
+                    z = entity.Z;
+                    id = entity.ID;
+                }
+            }
+
+            Engine.SendPacketToServer( new Target( TargetTypeEnum.Object, senderSerial, Engine.TargetFlags, serial, x, y, z, id,
                 true ) );
             Engine.TargetExists = false;
         }

--- a/ClassicAssist/UI/Views/ECV/Filter/EntityCollectionFilterViewModel.cs
+++ b/ClassicAssist/UI/Views/ECV/Filter/EntityCollectionFilterViewModel.cs
@@ -33,6 +33,7 @@ using ClassicAssist.Shared.Resources;
 using ClassicAssist.Shared.UI;
 using ClassicAssist.UI.Views.ECV.Filter.Models;
 using ClassicAssist.UO.Data;
+using ClassicAssist.UO.Objects;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Sentry;
@@ -169,6 +170,26 @@ namespace ClassicAssist.UI.Views.ECV.Filter
                     bool match = organizer.Items.Any( e => e.ID == item.ID && ( e.Hue == -1 || e.Hue == item.Hue ) );
 
                     return entry.Operator == AutolootOperator.NotEqual ? !match : match;
+                },
+                Options = new ObservableCollection<string>( OrganizerManager.GetInstance().Items?.Select( o => o.Name ) ?? new List<string>() )
+            } );
+
+            Constraints.AddSorted( new PropertyEntry
+            {
+                Name = "Is Multi",
+                ConstraintType = PropertyType.Predicate,
+                AllowedOperators = AutolootAllowedOperators.Equal | AutolootAllowedOperators.NotEqual,
+                Predicate = ( item, entry ) =>
+                {
+                    switch ( entry.Operator )
+                    {
+                        case AutolootOperator.Equal:
+                            return item is Item i && i.ArtDataID == 2;
+                        case AutolootOperator.NotEqual:
+                            return item is Item i2 && i2.ArtDataID != 2;
+                        default:
+                            return false;
+                    }
                 },
                 Options = new ObservableCollection<string>( OrganizerManager.GetInstance().Items?.Select( o => o.Name ) ?? new List<string>() )
             } );

--- a/ClassicAssist/UO/Commands.cs
+++ b/ClassicAssist/UO/Commands.cs
@@ -1008,6 +1008,11 @@ namespace ClassicAssist.UO
                     ? (Entity) Engine.Mobiles.GetMobile( serial )
                     : Engine.Items.GetItem( serial );
 
+                if ( UOMath.IsMobile( serial ) && entity == null )
+                {
+                    entity = Engine.Items.SelectEntity( i => i.Serial == serial && i.ArtDataID == 3 ); // Damageable items??
+                }
+
                 if ( entity == null )
                 {
                     SystemMessage( Strings.Cannot_find_item___ );

--- a/ClassicAssist/UO/Network/IncomingPacketHandlers.cs
+++ b/ClassicAssist/UO/Network/IncomingPacketHandlers.cs
@@ -373,9 +373,9 @@ namespace ClassicAssist.UO.Network
         {
             int serial = reader.ReadInt32();
 
-            QuestPointer pointer = Engine.QuestPointers.FirstOrDefault( p => p.Serial == serial );
+            QuestPointer[] pointers = Engine.QuestPointers.Where( p => p.Serial == serial ).ToArray();
 
-            if ( pointer != null )
+            foreach ( QuestPointer pointer in pointers )
             {
                 Engine.QuestPointers.Remove( pointer );
             }

--- a/ClassicAssist/UO/Network/IncomingPacketHandlers.cs
+++ b/ClassicAssist/UO/Network/IncomingPacketHandlers.cs
@@ -1459,6 +1459,8 @@ namespace ClassicAssist.UO.Network
                 Engine.Player.Map = map;
             }
 
+            Engine.Items.ClearMultis();
+
             MapChangedEvent?.Invoke( map );
         }
 
@@ -1564,6 +1566,7 @@ namespace ClassicAssist.UO.Network
             {
                 Engine.Mobiles.Remove( serial );
                 Engine.Items.RemoveByOwner( serial );
+                Engine.Items.Remove( serial ); // For damageable objects with mobile serials
             }
             else
             {

--- a/ClassicAssist/UO/Objects/ItemCollection.cs
+++ b/ClassicAssist/UO/Objects/ItemCollection.cs
@@ -307,6 +307,40 @@ namespace ClassicAssist.UO.Objects
             Remove( items );
         }
 
+        public override void RemoveByDistance( int maxDistance, int x, int y )
+        {
+            Item[] items = SelectEntities( i => i is Item item && item.Owner == 0 && UOMath.Distance( x, y, item.X, item.Y ) > maxDistance && i.ArtDataID != 2 );
+
+            if ( items == null )
+            {
+                return;
+            }
+
+            bool changed = Remove( items );
+
+            if ( changed )
+            {
+                OnCollectionChanged( false, items );
+            }
+        }
+
+        public void ClearMultis()
+        {
+            Item[] items = SelectEntities( i => i is Item item && i.ArtDataID == 2 );
+
+            if ( items == null )
+            {
+                return;
+            }
+
+            bool changed = Remove( items );
+
+            if ( changed )
+            {
+                OnCollectionChanged( false, items );
+            }
+        }
+
         public override Item[] SelectEntities( Func<Item, bool> func )
         {
             List<Item> itemList = new List<Item>();


### PR DESCRIPTION
## Summary

Object/packet removal fixes and support for damageable objects and multis.

## Changes

- **Fix object removal + damageable/multi handling** — correct removal handling for world objects and add handling for damageable objects and multis (targeting, filtering, item collection, and incoming packet paths).
- **QuestPointer removal handles duplicates** — fix QuestPointer removal so duplicate pointers are all cleared.

## Notes

Cherry-picked from a larger feature branch. Builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
