### PR TITLE
Entity Collection Viewer: weight sort, lock/unlock, and live property refresh

### DIFF
--- a/ClassicAssist.Shared/Resources/Strings.Designer.cs
+++ b/ClassicAssist.Shared/Resources/Strings.Designer.cs
@@ -3424,6 +3424,24 @@ namespace ClassicAssist.Shared.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Lock Item.
+        /// </summary>
+        public static string Lock_item {
+            get {
+                return ResourceManager.GetString("Lock item", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Unlock Item.
+        /// </summary>
+        public static string Unlock_item {
+            get {
+                return ResourceManager.GetString("Unlock item", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Move to backpack.
         /// </summary>
         public static string Move_to_backpack {

--- a/ClassicAssist.Shared/Resources/Strings.resx
+++ b/ClassicAssist.Shared/Resources/Strings.resx
@@ -1579,6 +1579,12 @@ Are you sure you wish to continue?</value>
   <data name="No items..." xml:space="preserve">
     <value>No items...</value>
   </data>
+  <data name="Lock item" xml:space="preserve">
+    <value>Lock Item</value>
+  </data>
+  <data name="Unlock item" xml:space="preserve">
+    <value>Unlock Item</value>
+  </data>
   <data name="Backing up {0}..." xml:space="preserve">
     <value>Backing up {0}...</value>
   </data>

--- a/ClassicAssist.Tests/ECV/EntityCollectionDataTests.cs
+++ b/ClassicAssist.Tests/ECV/EntityCollectionDataTests.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using ClassicAssist.UI.ViewModels;
+using ClassicAssist.UO.Objects;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ClassicAssist.Tests.ECV
+{
+    [TestClass]
+    public class EntityCollectionDataTests
+    {
+        [TestMethod]
+        public void NotifyPropertiesUpdatedRaisesChangeForDisplayedProperties()
+        {
+            EntityCollectionData data = new EntityCollectionData { Entity = new Item( 0x40000001 ) };
+
+            List<string> raised = new List<string>();
+
+            void OnPropertyChanged( object sender, PropertyChangedEventArgs e )
+            {
+                raised.Add( e.PropertyName );
+            }
+
+            data.PropertyChanged += OnPropertyChanged;
+
+            try
+            {
+                data.NotifyPropertiesUpdated();
+            }
+            finally
+            {
+                data.PropertyChanged -= OnPropertyChanged;
+            }
+
+            CollectionAssert.Contains( raised, nameof( EntityCollectionData.Name ) );
+            CollectionAssert.Contains( raised, nameof( EntityCollectionData.FullName ) );
+            CollectionAssert.Contains( raised, "Bitmap" );
+        }
+    }
+}

--- a/ClassicAssist.Tests/IncomingPacketHandlerTests.cs
+++ b/ClassicAssist.Tests/IncomingPacketHandlerTests.cs
@@ -125,5 +125,49 @@ namespace ClassicAssist.Tests
 
             Engine.Player = null;
         }
+
+        [TestMethod]
+        public void WillFireItemPropertiesUpdatedEventOnProperties()
+        {
+            const int itemSerial = 0x40000002;
+
+            // 0xD6 (Object Property List): id, length, word, serial, word, hash, then a zero cliloc
+            // terminator (empty property list keeps the test independent of Cliloc data files).
+            byte[] packet =
+            {
+                0xD6,
+                0x00, 0x13, // length
+                0x00, 0x01, // word 1
+                0x40, 0x00, 0x00, 0x02, // serial
+                0x00, 0x00, // word 0
+                0x00, 0x00, 0x00, 0x00, // hash
+                0x00, 0x00, 0x00, 0x00 // cliloc terminator
+            };
+
+            PacketHandler handler = IncomingPacketHandlers.GetHandler( 0xD6 );
+
+            Assert.IsNotNull( handler );
+
+            Item firedItem = null;
+
+            void OnItemPropertiesUpdated( Item item )
+            {
+                firedItem = item;
+            }
+
+            IncomingPacketHandlers.ItemPropertiesUpdatedEvent += OnItemPropertiesUpdated;
+
+            try
+            {
+                handler.OnReceive( new PacketReader( packet, packet.Length, false ) );
+            }
+            finally
+            {
+                IncomingPacketHandlers.ItemPropertiesUpdatedEvent -= OnItemPropertiesUpdated;
+            }
+
+            Assert.IsNotNull( firedItem, "ItemPropertiesUpdatedEvent did not fire." );
+            Assert.AreEqual( itemSerial, firedItem.Serial );
+        }
     }
 }

--- a/ClassicAssist.Tests/ItemCollectionTests.cs
+++ b/ClassicAssist.Tests/ItemCollectionTests.cs
@@ -1,0 +1,112 @@
+using Assistant;
+using ClassicAssist.UO.Objects;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ClassicAssist.Tests
+{
+    [TestClass]
+    public class ItemCollectionTests
+    {
+        [TestCleanup]
+        public void Cleanup()
+        {
+            Engine.Items.Clear();
+        }
+
+        [TestMethod]
+        public void WillFireCollectionChangedOnRemoveOfNestedItem()
+        {
+            // Container registered in the top-level Engine.Items collection.
+            Item container = new Item( 0x40000001 ) { Container = new ItemCollection( 0x40000001 ) };
+            Engine.Items.Add( container );
+
+            // Item nested inside the container's own collection.
+            Item item = new Item( 0x40000002, 0x40000001 ) { ID = 0xff };
+            container.Container.Add( item );
+
+            bool removedFired = false;
+
+            container.Container.CollectionChanged += ( total, added, entities ) =>
+            {
+                if ( !added )
+                {
+                    removedFired = true;
+                }
+            };
+
+            // Simulate the server deleting the item (OnItemDeleted -> Engine.Items.Remove).
+            Engine.Items.Remove( item.Serial );
+
+            Assert.AreEqual( 0, container.Container.GetItemCount(), "Item was not removed from the container collection." );
+            Assert.IsTrue( removedFired, "CollectionChanged did not fire for the removed item." );
+        }
+
+        [TestMethod]
+        public void WillBubbleCollectionChangedToRootContainerFromNestedContainer()
+        {
+            // Three-level hierarchy: root -> sub -> subsub -> item.
+            Item root = new Item( 0x40000001 ) { Container = new ItemCollection( 0x40000001 ) };
+            Engine.Items.Add( root );
+
+            Item sub = new Item( 0x40000002, 0x40000001 ) { Container = new ItemCollection( 0x40000002 ) };
+            root.Container.Add( sub );
+
+            Item subSub = new Item( 0x40000003, 0x40000002 ) { Container = new ItemCollection( 0x40000003 ) };
+            sub.Container.Add( subSub );
+
+            Item item = new Item( 0x40000004, 0x40000003 ) { ID = 0xff };
+            subSub.Container.Add( item );
+
+            bool addedFired = false;
+            bool removedFired = false;
+
+            // A viewer on the root container (as in ShowChildItems mode) subscribes here.
+            root.Container.CollectionChanged += ( total, added, entities ) =>
+            {
+                if ( added )
+                {
+                    addedFired = true;
+                }
+                else
+                {
+                    removedFired = true;
+                }
+            };
+
+            // Add a new deeply-nested item - should bubble to the root.
+            Item newItem = new Item( 0x40000005, 0x40000003 ) { ID = 0xfe };
+            subSub.Container.Add( newItem );
+
+            Assert.IsTrue( addedFired, "Add of a deeply-nested item did not bubble up to the root container." );
+
+            // Remove a deeply-nested item - should bubble to the root.
+            Engine.Items.Remove( item.Serial );
+
+            Assert.IsTrue( removedFired, "Removal of a deeply-nested item did not bubble up to the root container." );
+        }
+
+        [TestMethod]
+        public void WillFireCollectionChangedOnRemoveOfDirectItem()
+        {
+            ItemCollection collection = new ItemCollection( 0x40000001 );
+
+            Item item = new Item( 0x40000002, 0x40000001 ) { ID = 0xff };
+            collection.Add( item );
+
+            bool removedFired = false;
+
+            collection.CollectionChanged += ( total, added, entities ) =>
+            {
+                if ( !added )
+                {
+                    removedFired = true;
+                }
+            };
+
+            collection.Remove( item.Serial );
+
+            Assert.AreEqual( 0, collection.GetItemCount() );
+            Assert.IsTrue( removedFired, "CollectionChanged did not fire for the removed item." );
+        }
+    }
+}

--- a/ClassicAssist/Data/Misc/EntityCollectionViewerOptions.cs
+++ b/ClassicAssist/Data/Misc/EntityCollectionViewerOptions.cs
@@ -34,6 +34,7 @@ namespace ClassicAssist.Data.Misc
         private ObservableCollection<Assembly> _assemblies = new ObservableCollection<Assembly>();
         private ObservableCollection<CombineStacksOpenContainersIgnoreEntry> _combineStacksIgnore;
         private ObservableCollection<ContainerSet> _containerSets = new ObservableCollection<ContainerSet>();
+        private ObservableCollection<int> _lockedItems = new ObservableCollection<int>();
         private ObservableCollection<CombineStacksOpenContainersIgnoreEntry> _openContainersIgnore;
         private bool _openContainersOnlyKnownContainers;
         private bool _showChildItems;
@@ -63,6 +64,12 @@ namespace ClassicAssist.Data.Misc
         }
 
         public string Hash { get; set; }
+
+        public ObservableCollection<int> LockedItems
+        {
+            get => _lockedItems;
+            set => SetProperty( ref _lockedItems, value );
+        }
 
         public ObservableCollection<CombineStacksOpenContainersIgnoreEntry> OpenContainersIgnore
         {
@@ -94,6 +101,8 @@ namespace ClassicAssist.Data.Misc
             options.AlwaysOnTop = config["AlwaysOnTop"]?.ToObject<bool>() ?? false;
             options.ShowChildItems = config["ShowChildItems"]?.ToObject<bool>() ?? false;
             options.OpenContainersOnlyKnownContainers = config["OpenContainersOnlyKnownContainers"]?.ToObject<bool>() ?? false;
+
+            options.LockedItems = config["LockedItems"]?.ToObject<ObservableCollection<int>>() ?? new ObservableCollection<int>();
 
             options.CombineStacksIgnore = new ObservableCollection<CombineStacksOpenContainersIgnoreEntry>();
 
@@ -165,6 +174,11 @@ namespace ClassicAssist.Data.Misc
         public static JToken Serialize( EntityCollectionViewerOptions options )
         {
             JObject config = new JObject { { "AlwaysOnTop", options.AlwaysOnTop }, { "ShowChildItems", options.ShowChildItems } };
+
+            if ( options.LockedItems != null )
+            {
+                config.Add( "LockedItems", new JArray( from serial in options.LockedItems select serial ) );
+            }
 
             JArray combineStacksIgnore = new JArray();
 

--- a/ClassicAssist/Misc/EntityComparers.cs
+++ b/ClassicAssist/Misc/EntityComparers.cs
@@ -1,5 +1,27 @@
-﻿using System;
+﻿#region License
+
+// Copyright (C) 2026 Reetus
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#endregion
+
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using Assistant;
+using ClassicAssist.UO.Data;
 using ClassicAssist.UO.Objects;
 
 namespace ClassicAssist.Misc
@@ -74,6 +96,51 @@ namespace ClassicAssist.Misc
             int result = itemX.Count.CompareTo( itemY.Count );
 
             return result == 0 ? x.Serial.CompareTo( y.Serial ) : result;
+        }
+    }
+
+    public class WeightThenSerialComparer : IComparer<Entity>
+    {
+        public int Compare( Entity x, Entity y )
+        {
+            if ( x == null || y == null )
+            {
+                return -1;
+            }
+
+            if ( !( x is Item itemX ) || !( y is Item itemY ) )
+            {
+                return 0;
+            }
+
+            if ( !Engine.CharacterListFlags.HasFlag( CharacterListFlags.PaladinNecromancerClassTooltips ) )
+            {
+                byte weightX = TileData.GetStaticTile( itemX.ID ).Weight;
+                byte weightY = TileData.GetStaticTile( itemY.ID ).Weight;
+
+                int result = weightX.CompareTo( weightY );
+
+                return result == 0 ? x.Serial.CompareTo( y.Serial ) : result;
+            }
+            else
+            {
+                int itemXWeight = Convert.ToInt32( itemX.Properties.FirstOrDefault( p => p.Cliloc == 1072225 || p.Cliloc == 1072788 )?.Arguments[0] ?? "-1" );
+                int itemYWeight = Convert.ToInt32( itemY.Properties.FirstOrDefault( p => p.Cliloc == 1072225 || p.Cliloc == 1072788 )?.Arguments[0] ?? "-1" );
+
+                if ( itemXWeight == -1 )
+                {
+                    itemXWeight = TileData.GetStaticTile( itemX.ID ).Weight;
+                }
+
+                if ( itemYWeight == -1 )
+                {
+                    itemYWeight = TileData.GetStaticTile( itemY.ID ).Weight;
+                }
+
+                int result = itemXWeight.CompareTo( itemYWeight );
+
+                return result == 0 ? x.Serial.CompareTo( y.Serial ) : result;
+            }
         }
     }
 }

--- a/ClassicAssist/UI/Models/EntityCollectionSortStyle.cs
+++ b/ClassicAssist/UI/Models/EntityCollectionSortStyle.cs
@@ -6,6 +6,7 @@ namespace ClassicAssist.UI.Models
         Serial,
         Hue,
         ID,
-        Quantity
+        Quantity,
+        Weight
     }
 }

--- a/ClassicAssist/UI/ViewModels/EntityCollectionData.cs
+++ b/ClassicAssist/UI/ViewModels/EntityCollectionData.cs
@@ -13,6 +13,7 @@
 #endregion
 
 using ClassicAssist.Misc;
+using ClassicAssist.Shared.UI;
 using ClassicAssist.UO.Data;
 using ClassicAssist.UO.Objects;
 using System.Collections.Generic;
@@ -22,11 +23,18 @@ using System.Windows.Media;
 
 namespace ClassicAssist.UI.ViewModels
 {
-    public class EntityCollectionData
+    public class EntityCollectionData : SetPropertyNotifyChanged
     {
         private readonly Dictionary<int, ImageSource> _cache = new Dictionary<int, ImageSource>();
+        private bool _isLocked;
 
         public bool IsCoin => Entity?.ID == 0x0EEA || Entity?.ID == 0x0EED || Entity?.ID == 0x0EF0;
+
+        public bool IsLocked
+        {
+            get => _isLocked;
+            set => SetProperty( ref _isLocked, value );
+        }
 
         public ImageSource Bitmap
         {

--- a/ClassicAssist/UI/ViewModels/EntityCollectionData.cs
+++ b/ClassicAssist/UI/ViewModels/EntityCollectionData.cs
@@ -95,6 +95,18 @@ namespace ClassicAssist.UI.ViewModels
 
         public string Name => GetName( Entity );
 
+        /// <summary>
+        ///     Re-raises change notification for the computed, entity-derived properties. Called when the
+        ///     underlying entity's name/properties/hue are updated after the row was created (e.g. an OPL
+        ///     packet arriving after the item was added to the viewer).
+        /// </summary>
+        public void NotifyPropertiesUpdated()
+        {
+            OnPropertyChanged( nameof( Name ) );
+            OnPropertyChanged( nameof( FullName ) );
+            OnPropertyChanged( nameof( Bitmap ) );
+        }
+
         private static string GetProperties( Entity entity )
         {
             return entity.Properties == null

--- a/ClassicAssist/UI/ViewModels/EntityCollectionViewerViewModel.cs
+++ b/ClassicAssist/UI/ViewModels/EntityCollectionViewerViewModel.cs
@@ -30,6 +30,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
+using System.Windows.Media;
 using Assistant;
 using ClassicAssist.Data;
 using ClassicAssist.Data.Autoloot;
@@ -73,6 +74,7 @@ namespace ClassicAssist.UI.ViewModels
         private ICommand _contextOpenContainerCommand;
         private ICommand _contextTargetCommand;
         private ICommand _contextTargetOwnerCommand;
+        private ICommand _contextToggleLockCommand;
         private ICommand _contextUseItemCommand;
         private ObservableCollection<EntityCollectionData> _entities;
         private ICommand _equipItemCommand;
@@ -154,6 +156,7 @@ namespace ClassicAssist.UI.ViewModels
                 }
 
                 UpdateStatusLabel();
+                OnPropertyChanged( nameof( SelectedItemsAllLocked ) );
             };
 
             UpdateStatusLabel();
@@ -210,14 +213,21 @@ namespace ClassicAssist.UI.ViewModels
         public ICommand ContextTargetOwnerCommand =>
             _contextTargetOwnerCommand ?? ( _contextTargetOwnerCommand = new RelayCommand( ContextTargetOwner, o => SelectedItems.Any() && SelectedItems.Count == 1 ) );
 
+        public ICommand ContextToggleLockCommand =>
+            _contextToggleLockCommand ?? ( _contextToggleLockCommand = new RelayCommand( ContextToggleLock, o => SelectedItems != null && SelectedItems.Count > 0 ) );
+
         public ICommand ContextUseItemCommand => _contextUseItemCommand ?? ( _contextUseItemCommand = new RelayCommandAsync( ContextUseItem, o => SelectedItems != null ) );
+
+        public static ImageSource PadlockIcon { get; } = Properties.Resources.padlock.ToImageSource();
+
+        public bool SelectedItemsAllLocked => SelectedItems.Count > 0 && SelectedItems.All( e => e.IsLocked );
 
         public ObservableCollection<KeyValuePair<string, Action<Item>>> CustomContextActions { get; set; } = new ObservableCollection<KeyValuePair<string, Action<Item>>>();
 
         public ObservableCollection<EntityCollectionData> Entities
         {
             get => _entities;
-            set => SetProperty( ref _entities, value );
+            set => SetProperty( ref _entities, value, afterChange: _ => ApplyLockState() );
         }
 
         public ICommand EquipItemCommand => _equipItemCommand ?? ( _equipItemCommand = new RelayCommandAsync( EquipItem, o => SelectedItems != null ) );
@@ -423,7 +433,7 @@ namespace ClassicAssist.UI.ViewModels
                 return;
             }
 
-            int[] items = SelectedItems.Select( i => i.Entity.Serial ).ToArray();
+            int[] items = SelectedItems.Where( i => !i.IsLocked ).Select( i => i.Entity.Serial ).ToArray();
 
             EnqueueAction( async obj =>
             {
@@ -453,7 +463,7 @@ namespace ClassicAssist.UI.ViewModels
                 return;
             }
 
-            Item[] items = SelectedItems.Where( i => i.Entity is Item ).Select( i => i.Entity ).Cast<Item>().ToArray();
+            Item[] items = SelectedItems.Where( i => i.Entity is Item && !i.IsLocked ).Select( i => i.Entity ).Cast<Item>().ToArray();
 
             EnqueueAction( async obj =>
             {
@@ -831,6 +841,8 @@ namespace ClassicAssist.UI.ViewModels
                         Entities.Add( entity.ToEntityCollectionData( _nameOverrides ) );
                     }
 
+                    ApplyLockState();
+
                     if ( _filters != null )
                     {
                         ApplyFilters( _filters );
@@ -933,6 +945,45 @@ namespace ClassicAssist.UI.ViewModels
             {
                 Commands.RemoveObject( entity.Serial );
             }
+        }
+
+        private void ApplyLockState()
+        {
+            if ( _entities == null || Options?.LockedItems == null )
+            {
+                return;
+            }
+
+            foreach ( EntityCollectionData ecd in _entities )
+            {
+                ecd.IsLocked = Options.LockedItems.Contains( ecd.Entity.Serial );
+            }
+        }
+
+        private void ContextToggleLock( object obj )
+        {
+            bool lockTarget = !SelectedItemsAllLocked;
+
+            foreach ( EntityCollectionData ecd in SelectedItems.ToList() )
+            {
+                ecd.IsLocked = lockTarget;
+
+                if ( lockTarget )
+                {
+                    if ( !Options.LockedItems.Contains( ecd.Entity.Serial ) )
+                    {
+                        Options.LockedItems.Add( ecd.Entity.Serial );
+                    }
+                }
+                else
+                {
+                    Options.LockedItems.Remove( ecd.Entity.Serial );
+                }
+            }
+
+            SaveOptions( Options );
+
+            OnPropertyChanged( nameof( SelectedItemsAllLocked ) );
         }
 
         ~EntityCollectionViewerViewModel()
@@ -1314,7 +1365,7 @@ namespace ClassicAssist.UI.ViewModels
 
         private async Task ContextMoveToContainer( object arg )
         {
-            int[] items = SelectedItems.Select( i => i.Entity.Serial ).ToArray();
+            int[] items = SelectedItems.Where( i => !i.IsLocked ).Select( i => i.Entity.Serial ).ToArray();
 
             int serial = 0;
 

--- a/ClassicAssist/UI/ViewModels/EntityCollectionViewerViewModel.cs
+++ b/ClassicAssist/UI/ViewModels/EntityCollectionViewerViewModel.cs
@@ -54,9 +54,10 @@ using Newtonsoft.Json.Linq;
 
 namespace ClassicAssist.UI.ViewModels
 {
-    public class EntityCollectionViewerViewModel : BaseViewModel
+    public class EntityCollectionViewerViewModel : BaseViewModel, IDisposable
     {
         private readonly Func<ItemCollection> _customRefreshCommand;
+        private ItemCollection _eventSource;
         private ICommand _applyFiltersCommand;
         private ICommand _autolootContainerCommand;
         private ICommand _changeSortStyleCommand;
@@ -161,7 +162,14 @@ namespace ClassicAssist.UI.ViewModels
 
             UpdateStatusLabel();
 
-            Collection.CollectionChanged += OnCollectionChanged;
+            // Subscribe to the real source container. In ShowChildItems mode Collection is
+            // replaced by a flattened copy, so we track the underlying container separately
+            // to keep receiving live add/remove notifications for (nested) child items.
+            SetEventSource( collection );
+
+            // Item names/properties arrive in a separate OPL packet slightly after the item is
+            // added, so refresh the displayed row when its properties are (re)populated.
+            IncomingPacketHandlers.ItemPropertiesUpdatedEvent += OnItemPropertiesUpdated;
 
             TooltipsEnabled = Engine.CharacterListFlags.HasFlag( CharacterListFlags.PaladinNecromancerClassTooltips );
 
@@ -827,6 +835,55 @@ namespace ClassicAssist.UI.ViewModels
             TargetCommands.Target( Collection.Serial );
         }
 
+        private void SetEventSource( ItemCollection source )
+        {
+            if ( ReferenceEquals( _eventSource, source ) )
+            {
+                return;
+            }
+
+            if ( _eventSource != null )
+            {
+                _eventSource.CollectionChanged -= OnCollectionChanged;
+            }
+
+            _eventSource = source;
+
+            if ( _eventSource != null )
+            {
+                _eventSource.CollectionChanged += OnCollectionChanged;
+            }
+        }
+
+        private void OnItemPropertiesUpdated( Item item )
+        {
+            // Runs on the network thread. Filter cheaply against the (thread-safe) collection so we
+            // only marshal to the UI thread for items this viewer actually displays.
+            if ( item == null || !Collection.GetItem( item.Serial, out _ ) )
+            {
+                return;
+            }
+
+            _dispatcher.Invoke( () =>
+            {
+                EntityCollectionData ecd = Entities.FirstOrDefault( e => e.Entity.Serial == item.Serial );
+
+                if ( ecd == null )
+                {
+                    return;
+                }
+
+                // OnProperties overwrites Item.Name with the server value, which would clobber a
+                // user-applied rename - re-apply the override before refreshing the row.
+                if ( _nameOverrides.TryGetValue( item.Serial, out string nameOverride ) )
+                {
+                    item.Name = nameOverride;
+                }
+
+                ecd.NotifyPropertiesUpdated();
+            } );
+        }
+
         private void OnCollectionChanged( int totalcount, bool added, Item[] entities )
         {
             if ( added )
@@ -986,11 +1043,23 @@ namespace ClassicAssist.UI.ViewModels
             OnPropertyChanged( nameof( SelectedItemsAllLocked ) );
         }
 
-        ~EntityCollectionViewerViewModel()
+        public void Dispose()
+        {
+            Dispose( true );
+            GC.SuppressFinalize( this );
+        }
+
+        protected virtual void Dispose( bool disposing )
         {
             SaveOptions( Options );
-            Collection.CollectionChanged -= OnCollectionChanged;
+            SetEventSource( null );
+            IncomingPacketHandlers.ItemPropertiesUpdatedEvent -= OnItemPropertiesUpdated;
             ThreadQueue?.Dispose();
+        }
+
+        ~EntityCollectionViewerViewModel()
+        {
+            Dispose( false );
         }
 
         private void OpenAllContainers( object obj )
@@ -1281,6 +1350,7 @@ namespace ClassicAssist.UI.ViewModels
                 Task.Run( () => _customRefreshCommand.Invoke() ).ContinueWith( t =>
                 {
                     Collection = t.Result;
+                    SetEventSource( t.Result );
                     Entities = new ObservableCollection<EntityCollectionData>( Collection.ToEntityCollectionData( _sorter, _nameOverrides ) );
 
                     if ( _filters != null )
@@ -1340,6 +1410,9 @@ namespace ClassicAssist.UI.ViewModels
             }
 
             Collection = !Options.ShowChildItems ? collection : new ItemCollection( collection.Serial ) { ItemCollection.GetAllItems( collection.GetItems() ) };
+
+            // Track the real container for live notifications, even when Collection is a flattened copy.
+            SetEventSource( collection );
 
             Entities = new ObservableCollection<EntityCollectionData>( Collection.ToEntityCollectionData( _sorter, _nameOverrides ) );
 

--- a/ClassicAssist/UI/ViewModels/EntityCollectionViewerViewModel.cs
+++ b/ClassicAssist/UI/ViewModels/EntityCollectionViewerViewModel.cs
@@ -99,6 +99,7 @@ namespace ClassicAssist.UI.ViewModels
         private ICommand _togglePropertiesCommand;
         private bool _tooltipsEnabled;
         private bool _topmost;
+        private ICommand _copyToClipboardCommand;
 
         public EntityCollectionViewerViewModel()
         {
@@ -294,6 +295,34 @@ namespace ClassicAssist.UI.ViewModels
         }
 
         private Dictionary<int, string> _nameOverrides { get; } = new Dictionary<int, string>();
+        public ICommand CopyToClipboardCommand => _copyToClipboardCommand ?? ( _copyToClipboardCommand = new RelayCommand( CopyToClipboard, o => true ) );
+
+        private void CopyToClipboard( object obj )
+        {
+            ObservableCollection<EntityCollectionData> items = SelectedItems.Any() ? SelectedItems : Entities;
+
+            StringBuilder stringBuilder = new StringBuilder();
+
+            foreach ( EntityCollectionData item in items )
+            {
+                stringBuilder.AppendLine( $"Serial: 0x{item.Entity.Serial:x8}" );
+                stringBuilder.AppendLine( "Properties:" );
+                stringBuilder.Append( item.FullName );
+
+                Layer layer = TileData.GetLayer( item.Entity.ID );
+
+                if ( layer != Layer.Invalid )
+                {
+                    stringBuilder.AppendLine();
+                    stringBuilder.AppendLine( $"Layer: {layer}" );
+                }
+
+                stringBuilder.AppendLine();
+                stringBuilder.AppendLine();
+            }
+
+            Clipboard.SetText( stringBuilder.ToString() );
+        }
 
         private void ContextTargetOwner( object obj )
         {
@@ -1173,6 +1202,11 @@ namespace ClassicAssist.UI.ViewModels
 
                 case EntityCollectionSortStyle.Quantity:
                     _sorter = new QuantityThenSerialComparer();
+
+                    break;
+
+                case EntityCollectionSortStyle.Weight:
+                    _sorter = new WeightThenSerialComparer();
 
                     break;
 

--- a/ClassicAssist/UI/Views/ECV/ContextMenu.xaml
+++ b/ClassicAssist/UI/Views/ECV/ContextMenu.xaml
@@ -42,6 +42,35 @@
                 <MenuItem Header="{x:Static resources:Strings.Open_container}"
                           Command="{Binding Source={StaticResource Proxy}, Path=Data.(viewModels:EntityCollectionViewerViewModel.ContextOpenContainerCommand)}" />
                 <Separator />
+                <MenuItem Header="{x:Static resources:Strings.Lock_item}"
+                          Command="{Binding Source={StaticResource Proxy}, Path=Data.(viewModels:EntityCollectionViewerViewModel.ContextToggleLockCommand)}">
+                    <MenuItem.Style>
+                        <Style TargetType="{x:Type MenuItem}" BasedOn="{StaticResource {x:Type MenuItem}}">
+                            <Style.Triggers>
+                                <DataTrigger
+                                    Binding="{Binding Source={StaticResource Proxy}, Path=Data.(viewModels:EntityCollectionViewerViewModel.SelectedItemsAllLocked)}"
+                                    Value="True">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </MenuItem.Style>
+                </MenuItem>
+                <MenuItem Header="{x:Static resources:Strings.Unlock_item}"
+                          Command="{Binding Source={StaticResource Proxy}, Path=Data.(viewModels:EntityCollectionViewerViewModel.ContextToggleLockCommand)}">
+                    <MenuItem.Style>
+                        <Style TargetType="{x:Type MenuItem}" BasedOn="{StaticResource {x:Type MenuItem}}">
+                            <Style.Triggers>
+                                <DataTrigger
+                                    Binding="{Binding Source={StaticResource Proxy}, Path=Data.(viewModels:EntityCollectionViewerViewModel.SelectedItemsAllLocked)}"
+                                    Value="False">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </MenuItem.Style>
+                </MenuItem>
+                <Separator />
                 <MenuItem Header="{x:Static resources:Strings.Context_menu_request}"
                           Command="{Binding Source={StaticResource Proxy}, Path=Data.(viewModels:EntityCollectionViewerViewModel.ContextContextMenuRequestCommand)}" />
                 <MenuItem Header="{x:Static resources:Strings.Equip_Item}"

--- a/ClassicAssist/UI/Views/ECV/ListStyles.xaml
+++ b/ClassicAssist/UI/Views/ECV/ListStyles.xaml
@@ -18,19 +18,27 @@
                                       CommandParameter="{Binding SelectedItem, ElementName=listView}" />
                     </DockPanel.InputBindings>
                     <StackPanel ContextMenu="{StaticResource ContextMenu}">
-                        <Image Source="{Binding (viewModels:EntityCollectionData.Bitmap)}" Height="32"
-                               DockPanel.Dock="Top" Stretch="Uniform"
-                               HorizontalAlignment="Center" />
+                        <Grid DockPanel.Dock="Top" HorizontalAlignment="Center">
+                            <Image Source="{Binding Bitmap}" Height="32"
+                                   Stretch="Uniform" HorizontalAlignment="Center" />
+                            <Image x:Name="LockIcon" Width="12" Height="12"
+                                   HorizontalAlignment="Right" VerticalAlignment="Bottom"
+                                   Source="{x:Static viewModels:EntityCollectionViewerViewModel.PadlockIcon}"
+                                   Visibility="Collapsed" />
+                        </Grid>
                         <Border x:Name="Border" BorderThickness="1">
-                            <TextBlock x:Name="TextBlock" Text="{Binding (viewModels:EntityCollectionData.Name)}"
+                            <TextBlock x:Name="TextBlock" Text="{Binding Name}"
                                        TextAlignment="Center"
                                        Foreground="{DynamicResource ThemeForegroundBrush}"
                                        DockPanel.Dock="Bottom" Padding="1" TextWrapping="WrapWithOverflow"
-                                       ToolTip="{Binding (viewModels:EntityCollectionData.FullName)}" />
+                                       ToolTip="{Binding FullName}" />
                         </Border>
                     </StackPanel>
                 </DockPanel>
                 <DataTemplate.Triggers>
+                    <DataTrigger Binding="{Binding IsLocked}" Value="True">
+                        <Setter TargetName="LockIcon" Property="Visibility" Value="Visible" />
+                    </DataTrigger>
                     <DataTrigger
                         Binding="{Binding IsSelected, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ListViewItem}}}"
                         Value="True">
@@ -47,7 +55,7 @@
                         <Setter Property="Width" Value="60" />
                         <Setter TargetName="TextBlock" Property="FontSize" Value="10" />
                         <Setter TargetName="TextBlock" Property="Text"
-                                Value="{Binding (viewModels:EntityCollectionData.Name)}" />
+                                Value="{Binding Name}" />
                     </DataTrigger>
                     <DataTrigger
                         Binding="{Binding Source={StaticResource Proxy}, Path=Data.(viewModels:EntityCollectionViewerViewModel.ShowProperties)}"
@@ -55,7 +63,7 @@
                         <Setter Property="Width" Value="120" />
                         <Setter TargetName="TextBlock" Property="FontSize" Value="10" />
                         <Setter TargetName="TextBlock" Property="Text"
-                                Value="{Binding (viewModels:EntityCollectionData.FullName)}" />
+                                Value="{Binding FullName}" />
                     </DataTrigger>
                 </DataTemplate.Triggers>
             </DataTemplate>

--- a/ClassicAssist/UI/Views/EntityCollectionViewer.xaml
+++ b/ClassicAssist/UI/Views/EntityCollectionViewer.xaml
@@ -6,7 +6,6 @@
     xmlns:viewModels="clr-namespace:ClassicAssist.UI.ViewModels"
     xmlns:resources="clr-namespace:ClassicAssist.Shared.Resources;assembly=ClassicAssist.Shared"
     xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
-    xmlns:uimisc="clr-namespace:ClassicAssist.UI.Misc"
     xmlns:models="clr-namespace:ClassicAssist.UI.Models"
     xmlns:valueConverters="clr-namespace:ClassicAssist.Shared.UI.ValueConverters;assembly=ClassicAssist.Shared"
     xmlns:filter="clr-namespace:ClassicAssist.UI.Views.ECV.Filter"
@@ -101,6 +100,9 @@
                     <MenuItem Header="{x:Static resources:Strings.Amount}"
                               Command="{Binding ChangeSortStyleCommand}"
                               CommandParameter="{x:Static models:EntityCollectionSortStyle.Quantity}" />
+                    <MenuItem Header="{x:Static resources:Strings.Item_Weight}"
+                              Command="{Binding ChangeSortStyleCommand}"
+                              CommandParameter="{x:Static models:EntityCollectionSortStyle.Weight}" />
                 </MenuItem>
             </Menu>
             <Button Height="24" Style="{StaticResource ToolbarButtonStyle}" Command="{Binding CombineStacksCommand}"
@@ -129,8 +131,7 @@
                       VerticalScrollBarVisibility="Auto">
             <filter:EntityCollectionFilterControl MaxHeight="400"
                                                   Command="{Binding DataContext.ApplyFiltersCommand, ElementName=window}"
-                                                  Assemblies="{Binding DataContext.Options.Assemblies, ElementName=window}"
-                                                  PresentationTraceSources.TraceLevel="High" />
+                                                  Assemblies="{Binding DataContext.Options.Assemblies, ElementName=window}" />
         </ScrollViewer>
         <Grid Grid.Row="2"
               Visibility="{Binding ShowOrganizer, Converter={StaticResource BooleanToVisibilityConverter}}">
@@ -147,6 +148,9 @@
             <i:Interaction.Behaviors>
                 <behaviours:MultiSelectionBehaviour SelectedItems="{Binding SelectedItems}" />
             </i:Interaction.Behaviors>
+            <ListView.InputBindings>
+                <KeyBinding Modifiers="Ctrl" Key="C" Command="{Binding CopyToClipboardCommand}" />
+            </ListView.InputBindings>
         </ListView>
         <ItemsControl ItemsSource="{Binding QueueActions}" Grid.Row="4">
             <ItemsControl.ItemTemplate>

--- a/ClassicAssist/UI/Views/EntityCollectionViewer.xaml.cs
+++ b/ClassicAssist/UI/Views/EntityCollectionViewer.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System;
+using System.Windows;
 
 namespace ClassicAssist.UI.Views
 {
@@ -10,6 +11,15 @@ namespace ClassicAssist.UI.Views
         public EntityCollectionViewer()
         {
             InitializeComponent();
+
+            Closed += OnClosed;
+        }
+
+        private void OnClosed( object sender, EventArgs e )
+        {
+            Closed -= OnClosed;
+
+            ( DataContext as IDisposable )?.Dispose();
         }
     }
 }

--- a/ClassicAssist/UO/Network/IncomingPacketHandlers.cs
+++ b/ClassicAssist/UO/Network/IncomingPacketHandlers.cs
@@ -36,6 +36,8 @@ namespace ClassicAssist.UO.Network
 
         public delegate void dGump( uint gumpId, int serial, Gump gump );
 
+        public delegate void dItemPropertiesUpdated( Item item );
+
         public delegate void dJournalEntryAdded( JournalEntry je );
 
         public delegate void dMapChanged( Map newMap );
@@ -67,6 +69,7 @@ namespace ClassicAssist.UO.Network
 
         public static event dVendorSellDisplay VendorSellDisplayEvent;
         public static event dJournalEntryAdded JournalEntryAddedEvent;
+        public static event dItemPropertiesUpdated ItemPropertiesUpdatedEvent;
         public static event dSkillUpdated SkillUpdatedEvent;
         public static event dSkillList SkillsListEvent;
         public static event dMobileUpdated MobileUpdatedEvent;
@@ -1666,6 +1669,8 @@ namespace ClassicAssist.UO.Network
 
                 item.Name = name;
                 item.Properties = propertyArray;
+
+                ItemPropertiesUpdatedEvent?.Invoke( item );
             }
         }
 

--- a/ClassicAssist/UO/Objects/ItemCollection.cs
+++ b/ClassicAssist/UO/Objects/ItemCollection.cs
@@ -264,7 +264,11 @@ namespace ClassicAssist.UO.Objects
                 {
                     Item owner = Engine.Items.GetItem( item.Owner );
 
-                    if ( owner?.Container?.GetItem( serial ) != null )
+                    // Only purge the item from the owner's container when it's a different
+                    // collection to this one. If it's the same collection, base.Remove below
+                    // handles the removal and raises CollectionChanged - removing it here first
+                    // would leave nothing for base.Remove to remove, swallowing the event.
+                    if ( !ReferenceEquals( owner?.Container, this ) && owner?.Container?.GetItem( serial ) != null )
                     {
                         owner.Container.EntityList.TryRemove( serial, out _ );
                     }
@@ -359,13 +363,15 @@ namespace ClassicAssist.UO.Objects
             return null;
         }
 
-        public void OnCollectionChanged( bool rippleDown, bool added, Item[] items )
+        public void OnCollectionChanged( bool rippleUp, bool added, Item[] items )
         {
             OnCollectionChanged( added, items );
 
-            // Ripple down
+            // Ripple up through every ancestor container so viewers watching a parent
+            // collection (e.g. the flattened ShowChildItems view) are notified of changes
+            // to any descendant, regardless of nesting depth.
 
-            if ( !rippleDown )
+            if ( !rippleUp )
             {
                 return;
             }
@@ -377,7 +383,7 @@ namespace ClassicAssist.UO.Objects
 
             if ( Engine.Items.GetItem( item.Owner, out Item parent ) )
             {
-                parent.Container?.OnCollectionChanged( false, added, items );
+                parent.Container?.OnCollectionChanged( true, added, items );
             }
         }
 


### PR DESCRIPTION
## Summary

Entity Collection Viewer enhancements: weight sorting, item locking, and live property refresh.

## Changes

- **Weight sort + copy-to-clipboard** — add a weight sort style/column and a copy-to-clipboard action in the viewer.
- **Lock / unlock items** — mark rows as locked so bulk actions can skip them; adds the `IsLocked` state, context-menu entries, and list styling.
- **Refresh item properties in viewers** — re-raise change notifications when an item's name/properties/hue arrive after the row was created (e.g. a late OPL packet), and improve nested-collection event handling. Includes new `EntityCollectionData` and `ItemCollection` unit tests.

## Notes

Cherry-picked from a larger feature branch. A couple of trivial context conflicts were resolved (a stray debug `PresentationTraceSources.TraceLevel="High"` attribute and a `_cache` field that a separate perf change had made `static`); the intended feature behavior is unchanged. This PR intentionally excludes the separate ECV toolbar-action extensibility work. Builds clean and the new ECV tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
