### PR TITLE
Entity Collection Viewer toolbar action extensibility

### DIFF
--- a/ClassicAssist/UI/ViewModels/EntityCollectionViewerViewModel.cs
+++ b/ClassicAssist/UI/ViewModels/EntityCollectionViewerViewModel.cs
@@ -42,6 +42,7 @@ using ClassicAssist.Shared.UI;
 using ClassicAssist.UI.Models;
 using ClassicAssist.UI.Views;
 using ClassicAssist.UI.Views.ECV;
+using ClassicAssist.UI.Views.ECV.Extensibility;
 using ClassicAssist.UI.Views.ECV.Filter.Models;
 using ClassicAssist.UO;
 using ClassicAssist.UO.Data;
@@ -78,6 +79,7 @@ namespace ClassicAssist.UI.ViewModels
         private ICommand _contextTargetOwnerCommand;
         private ICommand _contextToggleLockCommand;
         private ICommand _contextUseItemCommand;
+        private ObservableCollection<EntityCollectionViewerActionViewModel> _customToolbarActions;
         private ObservableCollection<EntityCollectionData> _entities;
         private ICommand _equipItemCommand;
         private List<EntityCollectionFilterGroup> _filters;
@@ -176,6 +178,27 @@ namespace ClassicAssist.UI.ViewModels
 
             ThreadQueue = new ThreadPriorityQueue<QueueAction>( ProcessQueue );
             QueueActions.CollectionChanged += QueueActions_CollectionChanged;
+
+            CustomToolbarActions = new ObservableCollection<EntityCollectionViewerActionViewModel>(
+                EntityCollectionViewerExtensions.ToolbarActions.Select( action =>
+                    new EntityCollectionViewerActionViewModel( action, CreateActionContext ) ) );
+        }
+
+        private IEntityCollectionViewerContext CreateActionContext()
+        {
+            Item[] selectedItems = SelectedItems.Where( e => e.Entity is Item ).Select( e => (Item) e.Entity ).ToArray();
+
+            return new EntityCollectionViewerActionContext( Collection, selectedItems, ShowProperties, () => _dispatcher.Invoke( () => Refresh( null ) ),
+                ( action, status ) => EnqueueAction( queueAction =>
+                {
+                    if ( queueAction.CancellationTokenSource.IsCancellationRequested )
+                    {
+                        _dispatcher.Invoke( () => { queueAction.Status = Strings.Cancel; } );
+                        return Task.FromResult( false );
+                    }
+
+                    return Task.FromResult( action() );
+                }, status ) );
         }
 
         public ICommand ApplyFiltersCommand => _applyFiltersCommand ?? ( _applyFiltersCommand = new RelayCommand( ApplyFilters, o => true ) );
@@ -235,6 +258,12 @@ namespace ClassicAssist.UI.ViewModels
         public bool SelectedItemsAllLocked => SelectedItems.Count > 0 && SelectedItems.All( e => e.IsLocked );
 
         public ObservableCollection<KeyValuePair<string, Action<Item>>> CustomContextActions { get; set; } = new ObservableCollection<KeyValuePair<string, Action<Item>>>();
+
+        public ObservableCollection<EntityCollectionViewerActionViewModel> CustomToolbarActions
+        {
+            get => _customToolbarActions;
+            set => SetProperty( ref _customToolbarActions, value );
+        }
 
         public ObservableCollection<EntityCollectionData> Entities
         {

--- a/ClassicAssist/UI/Views/ECV/Extensibility/EntityCollectionViewerActionContext.cs
+++ b/ClassicAssist/UI/Views/ECV/Extensibility/EntityCollectionViewerActionContext.cs
@@ -1,0 +1,62 @@
+#region License
+
+// Copyright (C) 2026 Reetus
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#endregion
+
+using System;
+using ClassicAssist.UO.Objects;
+
+namespace ClassicAssist.UI.Views.ECV.Extensibility
+{
+    /// <summary>
+    ///     Default <see cref="IEntityCollectionViewerContext" /> implementation built by the
+    ///     Entity Collection Viewer view model when invoking a custom action. Captures a
+    ///     snapshot of the current collection/selection and forwards Refresh/EnqueueAction
+    ///     back to the view model.
+    /// </summary>
+    internal class EntityCollectionViewerActionContext : IEntityCollectionViewerContext
+    {
+        private readonly Action<Func<bool>, string> _enqueue;
+        private readonly Action _refresh;
+
+        public EntityCollectionViewerActionContext( ItemCollection collection, Item[] selectedItems, bool showProperties,
+            Action refresh, Action<Func<bool>, string> enqueue )
+        {
+            Collection = collection;
+            SelectedItems = selectedItems ?? Array.Empty<Item>();
+            ShowProperties = showProperties;
+            _refresh = refresh;
+            _enqueue = enqueue;
+        }
+
+        public ItemCollection Collection { get; }
+
+        public Item[] SelectedItems { get; }
+
+        public bool ShowProperties { get; }
+
+        public void Refresh()
+        {
+            _refresh?.Invoke();
+        }
+
+        public void EnqueueAction( Func<bool> action, string status )
+        {
+            _enqueue?.Invoke( action, status );
+        }
+    }
+}

--- a/ClassicAssist/UI/Views/ECV/Extensibility/EntityCollectionViewerActionViewModel.cs
+++ b/ClassicAssist/UI/Views/ECV/Extensibility/EntityCollectionViewerActionViewModel.cs
@@ -1,0 +1,68 @@
+#region License
+
+// Copyright (C) 2026 Reetus
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#endregion
+
+using System;
+using System.Windows.Input;
+using System.Windows.Media;
+using ClassicAssist.Shared.UI;
+
+namespace ClassicAssist.UI.Views.ECV.Extensibility
+{
+    /// <summary>
+    ///     Toolbar-button wrapper around a registered <see cref="IEntityCollectionViewerAction" />.
+    ///     Binds Name/Icon for display and invokes the action against a freshly built context.
+    /// </summary>
+    public class EntityCollectionViewerActionViewModel
+    {
+        private readonly IEntityCollectionViewerAction _action;
+        private readonly Func<IEntityCollectionViewerContext> _contextFactory;
+        private ICommand _executeCommand;
+
+        public EntityCollectionViewerActionViewModel( IEntityCollectionViewerAction action,
+            Func<IEntityCollectionViewerContext> contextFactory )
+        {
+            _action = action;
+            _contextFactory = contextFactory;
+        }
+
+        public string Name => _action.Name;
+
+        public ImageSource Icon => _action.Icon;
+
+        public ICommand ExecuteCommand =>
+            _executeCommand ?? ( _executeCommand = new RelayCommand( OnExecute, OnCanExecute ) );
+
+        private void OnExecute( object o )
+        {
+            _action.Execute( _contextFactory() );
+        }
+
+        private bool OnCanExecute( object o )
+        {
+            try
+            {
+                return _action.CanExecute( _contextFactory() );
+            }
+            catch ( Exception )
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/ClassicAssist/UI/Views/ECV/Extensibility/EntityCollectionViewerExtensions.cs
+++ b/ClassicAssist/UI/Views/ECV/Extensibility/EntityCollectionViewerExtensions.cs
@@ -1,0 +1,64 @@
+#region License
+
+// Copyright (C) 2026 Reetus
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+
+namespace ClassicAssist.UI.Views.ECV.Extensibility
+{
+    /// <summary>
+    ///     Registry of custom toolbar actions contributed by additional assemblies to the
+    ///     Entity Collection Viewer. Register actions from your assembly's static
+    ///     <c>Initialize()</c> method; each Entity Collection Viewer instance reads the
+    ///     registered actions when it is opened.
+    /// </summary>
+    public static class EntityCollectionViewerExtensions
+    {
+        private static readonly List<IEntityCollectionViewerAction> _toolbarActions = new List<IEntityCollectionViewerAction>();
+
+        /// <summary>
+        ///     The currently registered toolbar actions.
+        /// </summary>
+        public static IReadOnlyList<IEntityCollectionViewerAction> ToolbarActions => _toolbarActions;
+
+        /// <summary>
+        ///     Register a toolbar action. Has no effect if <paramref name="action" /> is already registered.
+        /// </summary>
+        public static void RegisterToolbarAction( IEntityCollectionViewerAction action )
+        {
+            if ( action == null )
+            {
+                throw new ArgumentNullException( nameof( action ) );
+            }
+
+            if ( !_toolbarActions.Contains( action ) )
+            {
+                _toolbarActions.Add( action );
+            }
+        }
+
+        /// <summary>
+        ///     Remove a previously registered toolbar action.
+        /// </summary>
+        public static bool UnregisterToolbarAction( IEntityCollectionViewerAction action )
+        {
+            return _toolbarActions.Remove( action );
+        }
+    }
+}

--- a/ClassicAssist/UI/Views/ECV/Extensibility/IEntityCollectionViewerAction.cs
+++ b/ClassicAssist/UI/Views/ECV/Extensibility/IEntityCollectionViewerAction.cs
@@ -1,0 +1,56 @@
+#region License
+
+// Copyright (C) 2026 Reetus
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#endregion
+
+using System.Windows.Media;
+
+namespace ClassicAssist.UI.Views.ECV.Extensibility
+{
+    /// <summary>
+    ///     A custom toolbar action that an additional assembly can register against the
+    ///     Entity Collection Viewer via
+    ///     <see cref="EntityCollectionViewerExtensions.RegisterToolbarAction" />, typically
+    ///     from its static <c>Initialize()</c> method.
+    /// </summary>
+    public interface IEntityCollectionViewerAction
+    {
+        /// <summary>
+        ///     Displayed as the toolbar button's tooltip.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        ///     Icon shown on the toolbar button. Should be a frozen <see cref="ImageSource" />
+        ///     (e.g. a <see cref="DrawingImage" />) so it is safe to render regardless of which
+        ///     thread it was created on. May be <c>null</c>.
+        /// </summary>
+        ImageSource Icon { get; }
+
+        /// <summary>
+        ///     Whether the action can run for the given context. Controls the button's enabled
+        ///     state; re-queried by WPF as the selection changes.
+        /// </summary>
+        bool CanExecute( IEntityCollectionViewerContext context );
+
+        /// <summary>
+        ///     Invoked when the toolbar button is clicked. Runs on the UI thread; use
+        ///     <see cref="IEntityCollectionViewerContext.EnqueueAction" /> for long-running work.
+        /// </summary>
+        void Execute( IEntityCollectionViewerContext context );
+    }
+}

--- a/ClassicAssist/UI/Views/ECV/Extensibility/IEntityCollectionViewerContext.cs
+++ b/ClassicAssist/UI/Views/ECV/Extensibility/IEntityCollectionViewerContext.cs
@@ -1,0 +1,59 @@
+#region License
+
+// Copyright (C) 2026 Reetus
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#endregion
+
+using System;
+using ClassicAssist.UO.Objects;
+
+namespace ClassicAssist.UI.Views.ECV.Extensibility
+{
+    /// <summary>
+    ///     Snapshot of the Entity Collection Viewer state passed to an
+    ///     <see cref="IEntityCollectionViewerAction" /> when it is invoked.
+    /// </summary>
+    public interface IEntityCollectionViewerContext
+    {
+        /// <summary>
+        ///     The full set of items currently shown in the viewer.
+        /// </summary>
+        ItemCollection Collection { get; }
+
+        /// <summary>
+        ///     The items currently selected in the viewer. Empty array if nothing is selected.
+        /// </summary>
+        Item[] SelectedItems { get; }
+
+        /// <summary>
+        ///     Whether the viewer is showing full item properties (<c>true</c>) or just item
+        ///     names (<c>false</c>) — the state of the viewer's "toggle item properties" button.
+        /// </summary>
+        bool ShowProperties { get; }
+
+        /// <summary>
+        ///     Refresh the viewer's contents.
+        /// </summary>
+        void Refresh();
+
+        /// <summary>
+        ///     Queue a long-running action on the viewer's action queue, surfacing
+        ///     <paramref name="status" /> in the viewer's status list with a cancel button.
+        ///     Return <c>false</c> from <paramref name="action" /> to indicate cancellation.
+        /// </summary>
+        void EnqueueAction( Func<bool> action, string status );
+    }
+}

--- a/ClassicAssist/UI/Views/EntityCollectionViewer.xaml
+++ b/ClassicAssist/UI/Views/EntityCollectionViewer.xaml
@@ -126,6 +126,32 @@
             <Button Height="24" Style="{StaticResource ToolbarButtonStyle}" Command="{Binding ConfigureCommand}">
                 <Image Source="{StaticResource configureIcon}" />
             </Button>
+            <ItemsControl ItemsSource="{Binding CustomToolbarActions}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Orientation="Horizontal" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Button Height="24" Padding="0"
+                                Command="{Binding ExecuteCommand}" ToolTip="{Binding Name}">
+                            <Button.Style>
+                                <Style TargetType="Button"
+                                       BasedOn="{StaticResource {x:Static ToolBar.ButtonStyleKey}}">
+                                    <Setter Property="Margin" Value="0,0,5,0" />
+                                    <Style.Triggers>
+                                        <Trigger Property="IsEnabled" Value="False">
+                                            <Setter Property="Image.Opacity" Value="0.5" />
+                                        </Trigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Button.Style>
+                            <Image Source="{Binding Icon}" />
+                        </Button>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
         </ToolBar>
         <ScrollViewer Grid.Row="1"
                       Visibility="{Binding ShowFilter, Converter={StaticResource BooleanToVisibilityConverter}}"


### PR DESCRIPTION
Allow external assemblies to contribute toolbar actions to the Entity Collection Viewer.

- New extensibility surface: `IEntityCollectionViewerAction` / `IEntityCollectionViewerContext`, an action view-model, an extensions/discovery helper, and an action context.
- Wire discovered actions into the viewer toolbar and view model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)