### PR TITLE
ECV sort persistence, filter fixes, and app-wide dark menu theming

### DIFF
--- a/ClassicAssist.Shared/Resources/DarkTheme.xaml
+++ b/ClassicAssist.Shared/Resources/DarkTheme.xaml
@@ -5,6 +5,7 @@
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="Colours.xaml" />
+        <ResourceDictionary Source="MenuStyles.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <Style x:Key="TreeViewItemStyle" TargetType="{x:Type TreeViewItem}">
@@ -1512,4 +1513,5 @@
             </Setter.Value>
         </Setter>
     </Style>
+
 </ResourceDictionary>

--- a/ClassicAssist.Shared/Resources/MenuStyles.xaml
+++ b/ClassicAssist.Shared/Resources/MenuStyles.xaml
@@ -1,0 +1,233 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="Colours.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+
+    <!-- ============================ Menus / Context menus ============================
+         Dark-themed default styles for Menu / MenuItem / ContextMenu. Kept in a standalone
+         dictionary so it can be merged both into the theme (for implicit app-wide styling)
+         and directly into any standalone ResourceDictionary (e.g. ECV/ContextMenu.xaml) whose
+         'BasedOn="{StaticResource {x:Type MenuItem}}"' would otherwise fall back to the WPF
+         system default style.
+
+         StaticResource is used for theme brushes so they bake in and resolve inside (nested)
+         submenu popups, which live in a disconnected visual tree. -->
+
+    <!-- Leaf submenu item (also handles checkable items via the check glyph). -->
+    <ControlTemplate x:Key="DarkMenuSubmenuItemTemplate" TargetType="{x:Type MenuItem}">
+        <Border x:Name="templateRoot" Background="{TemplateBinding Background}" SnapsToDevicePixels="True"
+                MinHeight="24">
+            <Grid Margin="2,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" MinWidth="24" SharedSizeGroup="MenuItemIconColumnGroup" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIGTColumnGroup" />
+                </Grid.ColumnDefinitions>
+                <ContentPresenter x:Name="Icon" Grid.Column="0" Content="{TemplateBinding Icon}"
+                                  ContentSource="Icon" Width="16" Height="16" Margin="3"
+                                  VerticalAlignment="Center" HorizontalAlignment="Center"
+                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                <Border x:Name="GlyphPanel" Grid.Column="0" Width="16" Height="16"
+                        Background="{StaticResource ThemeInnerControlBackgroundBrush}"
+                        BorderBrush="{StaticResource ThemeBorderBrush}" BorderThickness="1"
+                        VerticalAlignment="Center" HorizontalAlignment="Center" Visibility="Collapsed">
+                    <Path Width="10" Height="10" Stretch="Uniform"
+                          Fill="{StaticResource ThemeForegroundBrush}"
+                          Data="M0,4 L1.5,2.5 4,5 8.5,0.5 10,2 4,8 Z" />
+                </Border>
+                <ContentPresenter x:Name="menuHeader" Grid.Column="1" ContentSource="Header"
+                                  RecognizesAccessKey="True" Margin="6,0,12,0"
+                                  VerticalAlignment="Center" HorizontalAlignment="Left"
+                                  TextElement.Foreground="{TemplateBinding Foreground}"
+                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                <TextBlock Grid.Column="2" Text="{TemplateBinding InputGestureText}" Margin="6,0"
+                           VerticalAlignment="Center" Foreground="{StaticResource ThemeDisabledForegroundBrush}" />
+            </Grid>
+        </Border>
+        <ControlTemplate.Triggers>
+            <Trigger Property="Icon" Value="{x:Null}">
+                <Setter TargetName="Icon" Property="Visibility" Value="Collapsed" />
+            </Trigger>
+            <Trigger Property="IsChecked" Value="True">
+                <Setter TargetName="GlyphPanel" Property="Visibility" Value="Visible" />
+                <Setter TargetName="Icon" Property="Visibility" Value="Collapsed" />
+            </Trigger>
+            <Trigger Property="IsHighlighted" Value="True">
+                <Setter TargetName="templateRoot" Property="Background" Value="{StaticResource ThemeBorderBrush}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Foreground" Value="{StaticResource ThemeDisabledForegroundBrush}" />
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+
+    <!-- Submenu item that owns a nested submenu (shows arrow + opens child popup). -->
+    <ControlTemplate x:Key="DarkMenuSubmenuHeaderTemplate" TargetType="{x:Type MenuItem}">
+        <Border x:Name="templateRoot" Background="{TemplateBinding Background}" SnapsToDevicePixels="True"
+                MinHeight="24">
+            <Grid Margin="2,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" MinWidth="24" SharedSizeGroup="MenuItemIconColumnGroup" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" SharedSizeGroup="MenuItemIGTColumnGroup" />
+                    <ColumnDefinition Width="16" />
+                </Grid.ColumnDefinitions>
+                <ContentPresenter x:Name="Icon" Grid.Column="0" Content="{TemplateBinding Icon}"
+                                  ContentSource="Icon" Width="16" Height="16" Margin="3"
+                                  VerticalAlignment="Center" HorizontalAlignment="Center" />
+                <ContentPresenter x:Name="menuHeader" Grid.Column="1" ContentSource="Header"
+                                  RecognizesAccessKey="True" Margin="6,0,12,0"
+                                  VerticalAlignment="Center" HorizontalAlignment="Left"
+                                  TextElement.Foreground="{TemplateBinding Foreground}" />
+                <TextBlock Grid.Column="2" Text="{TemplateBinding InputGestureText}" Margin="6,0"
+                           VerticalAlignment="Center" Foreground="{StaticResource ThemeDisabledForegroundBrush}" />
+                <Path x:Name="Arrow" Grid.Column="3" VerticalAlignment="Center" HorizontalAlignment="Center"
+                      Data="M0,0 L4,4 0,8 Z" Fill="{StaticResource ThemeForegroundBrush}" />
+                <Popup x:Name="PART_Popup" AllowsTransparency="True" Focusable="False"
+                       IsOpen="{Binding IsSubmenuOpen, RelativeSource={RelativeSource TemplatedParent}}"
+                       Placement="Right" HorizontalOffset="-2" VerticalOffset="-3"
+                       PopupAnimation="{DynamicResource {x:Static SystemParameters.MenuPopupAnimationKey}}">
+                    <Border Background="{StaticResource ThemeBackgroundBrush}"
+                            BorderBrush="{StaticResource ThemeBorderBrush}" BorderThickness="1" Padding="2">
+                        <ItemsPresenter Grid.IsSharedSizeScope="True"
+                                        KeyboardNavigation.TabNavigation="Cycle"
+                                        KeyboardNavigation.DirectionalNavigation="Cycle"
+                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                    </Border>
+                </Popup>
+            </Grid>
+        </Border>
+        <ControlTemplate.Triggers>
+            <Trigger Property="Icon" Value="{x:Null}">
+                <Setter TargetName="Icon" Property="Visibility" Value="Collapsed" />
+            </Trigger>
+            <Trigger Property="IsHighlighted" Value="True">
+                <Setter TargetName="templateRoot" Property="Background" Value="{StaticResource ThemeBorderBrush}" />
+            </Trigger>
+            <Trigger Property="IsSubmenuOpen" Value="True">
+                <Setter TargetName="templateRoot" Property="Background" Value="{StaticResource ThemeBorderBrush}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Foreground" Value="{StaticResource ThemeDisabledForegroundBrush}" />
+                <Setter TargetName="Arrow" Property="Fill" Value="{StaticResource ThemeDisabledForegroundBrush}" />
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+
+    <!-- Top-level menu bar item that opens a submenu (e.g. an icon drop-down). -->
+    <ControlTemplate x:Key="DarkMenuTopLevelHeaderTemplate" TargetType="{x:Type MenuItem}">
+        <Border x:Name="templateRoot" Background="{TemplateBinding Background}" SnapsToDevicePixels="True">
+            <Grid VerticalAlignment="Center">
+                <ContentPresenter x:Name="menuHeader" ContentSource="Header" RecognizesAccessKey="True"
+                                  Margin="{TemplateBinding Padding}" VerticalAlignment="Center"
+                                  HorizontalAlignment="Center"
+                                  TextElement.Foreground="{TemplateBinding Foreground}" />
+                <Popup x:Name="PART_Popup" AllowsTransparency="True" Focusable="False"
+                       IsOpen="{Binding IsSubmenuOpen, RelativeSource={RelativeSource TemplatedParent}}"
+                       Placement="Bottom"
+                       PopupAnimation="{DynamicResource {x:Static SystemParameters.MenuPopupAnimationKey}}">
+                    <Border Background="{StaticResource ThemeBackgroundBrush}"
+                            BorderBrush="{StaticResource ThemeBorderBrush}" BorderThickness="1" Padding="2">
+                        <ItemsPresenter Grid.IsSharedSizeScope="True"
+                                        KeyboardNavigation.TabNavigation="Cycle"
+                                        KeyboardNavigation.DirectionalNavigation="Cycle"
+                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                    </Border>
+                </Popup>
+            </Grid>
+        </Border>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsHighlighted" Value="True">
+                <Setter TargetName="templateRoot" Property="Background" Value="{StaticResource ThemeBorderBrush}" />
+            </Trigger>
+            <Trigger Property="IsSubmenuOpen" Value="True">
+                <Setter TargetName="templateRoot" Property="Background" Value="{StaticResource ThemeBorderBrush}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Foreground" Value="{StaticResource ThemeDisabledForegroundBrush}" />
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+
+    <!-- Top-level menu bar leaf item (no submenu). -->
+    <ControlTemplate x:Key="DarkMenuTopLevelItemTemplate" TargetType="{x:Type MenuItem}">
+        <Border x:Name="templateRoot" Background="{TemplateBinding Background}" SnapsToDevicePixels="True">
+            <ContentPresenter x:Name="menuHeader" ContentSource="Header" RecognizesAccessKey="True"
+                              Margin="{TemplateBinding Padding}" VerticalAlignment="Center"
+                              HorizontalAlignment="Center"
+                              TextElement.Foreground="{TemplateBinding Foreground}" />
+        </Border>
+        <ControlTemplate.Triggers>
+            <Trigger Property="IsHighlighted" Value="True">
+                <Setter TargetName="templateRoot" Property="Background" Value="{StaticResource ThemeBorderBrush}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Foreground" Value="{StaticResource ThemeDisabledForegroundBrush}" />
+            </Trigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+
+    <Style x:Key="{x:Type MenuItem}" TargetType="{x:Type MenuItem}">
+        <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Foreground" Value="{StaticResource ThemeForegroundBrush}" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Padding" Value="8,3" />
+        <Setter Property="HorizontalContentAlignment" Value="Left" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="ScrollViewer.PanningMode" Value="Both" />
+        <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
+        <Setter Property="Template" Value="{StaticResource DarkMenuSubmenuItemTemplate}" />
+        <Style.Triggers>
+            <Trigger Property="Role" Value="TopLevelHeader">
+                <Setter Property="Template" Value="{StaticResource DarkMenuTopLevelHeaderTemplate}" />
+                <Setter Property="Padding" Value="6,0" />
+            </Trigger>
+            <Trigger Property="Role" Value="TopLevelItem">
+                <Setter Property="Template" Value="{StaticResource DarkMenuTopLevelItemTemplate}" />
+                <Setter Property="Padding" Value="6,0" />
+            </Trigger>
+            <Trigger Property="Role" Value="SubmenuHeader">
+                <Setter Property="Template" Value="{StaticResource DarkMenuSubmenuHeaderTemplate}" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <!-- Menu separator (scoped to menus via the framework separator key). -->
+    <Style x:Key="{x:Static MenuItem.SeparatorStyleKey}" TargetType="{x:Type Separator}">
+        <Setter Property="Margin" Value="4,3" />
+        <Setter Property="Background" Value="{StaticResource ThemeBorderBrush}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Separator}">
+                    <Border Height="1" Background="{TemplateBinding Background}"
+                            SnapsToDevicePixels="True" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="{x:Type ContextMenu}" TargetType="{x:Type ContextMenu}">
+        <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
+        <Setter Property="Background" Value="{StaticResource ThemeBackgroundBrush}" />
+        <Setter Property="Foreground" Value="{StaticResource ThemeForegroundBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource ThemeBorderBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ContextMenu}">
+                    <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}" Padding="2">
+                        <ItemsPresenter Grid.IsSharedSizeScope="True"
+                                        KeyboardNavigation.DirectionalNavigation="Cycle"
+                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>

--- a/ClassicAssist/UI/Models/EntityCollectionSortStyle.cs
+++ b/ClassicAssist/UI/Models/EntityCollectionSortStyle.cs
@@ -2,6 +2,7 @@ namespace ClassicAssist.UI.Models
 {
     public enum EntityCollectionSortStyle
     {
+        None,
         Name,
         Serial,
         Hue,

--- a/ClassicAssist/UI/ViewModels/EntityCollectionViewerViewModel.cs
+++ b/ClassicAssist/UI/ViewModels/EntityCollectionViewerViewModel.cs
@@ -97,7 +97,8 @@ namespace ClassicAssist.UI.ViewModels
 
         private bool _showProperties;
 
-        private IComparer<Entity> _sorter = new IDThenSerialComparer();
+        private IComparer<Entity> _sorter;
+        private EntityCollectionSortStyle _sortStyle = EntityCollectionSortStyle.None;
         private string _statusLabel;
         private ICommand _targetContainerCommand;
         private ICommand _toggleAlwaysOnTopCommand;
@@ -207,6 +208,12 @@ namespace ClassicAssist.UI.ViewModels
 
         public ICommand ChangeSortStyleCommand => _changeSortStyleCommand ?? ( _changeSortStyleCommand = new RelayCommand( ChangeSortStyle, o => true ) );
 
+        public EntityCollectionSortStyle SortStyle
+        {
+            get => _sortStyle;
+            set => SetProperty( ref _sortStyle, value );
+        }
+
         public ItemCollection Collection
         {
             get => _collection;
@@ -302,8 +309,19 @@ namespace ClassicAssist.UI.ViewModels
         public bool ShowFilter
         {
             get => _showFilter;
-            set => SetProperty( ref _showFilter, value );
+            set
+            {
+                SetProperty( ref _showFilter, value );
+
+                // Disabling the filter panel removes any currently applied filter.
+                if ( !value && _filters != null )
+                {
+                    ApplyFilters( null );
+                }
+            }
         }
+
+        public bool IsFilterApplied => _filters != null;
 
         public bool ShowOrganizer
         {
@@ -976,7 +994,24 @@ namespace ClassicAssist.UI.ViewModels
 
                     foreach ( Item entity in newEntities )
                     {
-                        Entities.Add( entity.ToEntityCollectionData( _nameOverrides ) );
+                        EntityCollectionData data = entity.ToEntityCollectionData( _nameOverrides );
+
+                        if ( _sorter == null )
+                        {
+                            Entities.Add( data );
+                        }
+                        else
+                        {
+                            // Keep the active sort applied as items stream in live, rather than appending unsorted.
+                            int index = 0;
+
+                            while ( index < Entities.Count && _sorter.Compare( Entities[index].Entity, entity ) <= 0 )
+                            {
+                                index++;
+                            }
+
+                            Entities.Insert( index, data );
+                        }
                     }
 
                     ApplyLockState();
@@ -1293,6 +1328,7 @@ namespace ClassicAssist.UI.ViewModels
             if ( !( obj is List<EntityCollectionFilterGroup> list ) )
             {
                 _filters = null;
+                OnPropertyChanged( nameof( IsFilterApplied ) );
 
                 Entities = new ObservableCollection<EntityCollectionData>( Collection.ToEntityCollectionData( _sorter, _nameOverrides ) );
 
@@ -1334,6 +1370,7 @@ namespace ClassicAssist.UI.ViewModels
             UpdateStatusLabel();
 
             _filters = list;
+            OnPropertyChanged( nameof( IsFilterApplied ) );
         }
 
         private static ItemCollection EvaluateGroup( EntityCollectionFilterGroup group, ItemCollection source )
@@ -1379,43 +1416,39 @@ namespace ClassicAssist.UI.ViewModels
                 return;
             }
 
-            switch ( val )
-            {
-                case EntityCollectionSortStyle.Name:
-                    _sorter = new NameThenSerialComparer();
-
-                    break;
-
-                case EntityCollectionSortStyle.Serial:
-                    _sorter = new SerialComparer();
-
-                    break;
-
-                case EntityCollectionSortStyle.Hue:
-                    _sorter = new HueThenAmountComparer();
-
-                    break;
-
-                case EntityCollectionSortStyle.ID:
-                    _sorter = new IDThenSerialComparer();
-
-                    break;
-
-                case EntityCollectionSortStyle.Quantity:
-                    _sorter = new QuantityThenSerialComparer();
-
-                    break;
-
-                case EntityCollectionSortStyle.Weight:
-                    _sorter = new WeightThenSerialComparer();
-
-                    break;
-
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
+            // Toggle: clicking the active sort style again clears the sort (back to no order).
+            SortStyle = SortStyle == val ? EntityCollectionSortStyle.None : val;
+            _sorter = GetComparer( SortStyle );
 
             Entities = new ObservableCollection<EntityCollectionData>( Collection.ToEntityCollectionData( _sorter, _nameOverrides ) );
+
+            if ( _filters != null )
+            {
+                ApplyFilters( _filters );
+            }
+        }
+
+        private static IComparer<Entity> GetComparer( EntityCollectionSortStyle style )
+        {
+            switch ( style )
+            {
+                case EntityCollectionSortStyle.None:
+                    return null;
+                case EntityCollectionSortStyle.Name:
+                    return new NameThenSerialComparer();
+                case EntityCollectionSortStyle.Serial:
+                    return new SerialComparer();
+                case EntityCollectionSortStyle.Hue:
+                    return new HueThenAmountComparer();
+                case EntityCollectionSortStyle.ID:
+                    return new IDThenSerialComparer();
+                case EntityCollectionSortStyle.Quantity:
+                    return new QuantityThenSerialComparer();
+                case EntityCollectionSortStyle.Weight:
+                    return new WeightThenSerialComparer();
+                default:
+                    throw new ArgumentOutOfRangeException( nameof( style ), style, null );
+            }
         }
 
         private void UpdateStatusLabel()
@@ -1796,7 +1829,9 @@ namespace ClassicAssist.UI.ViewModels
 
             Item[] items = itemCollection.GetItems();
 
-            return items.OrderBy( i => i, comparer ).Select( item => item.ToEntityCollectionData( nameOverrides ) ).ToList();
+            IEnumerable<Item> ordered = comparer == null ? items : (IEnumerable<Item>) items.OrderBy( i => i, comparer );
+
+            return ordered.Select( item => item.ToEntityCollectionData( nameOverrides ) ).ToList();
         }
 
         public static EntityCollectionData ToEntityCollectionData( this Item item, Dictionary<int, string> nameOverrides )

--- a/ClassicAssist/UI/ViewModels/EntityCollectionViewerViewModel.cs
+++ b/ClassicAssist/UI/ViewModels/EntityCollectionViewerViewModel.cs
@@ -146,12 +146,16 @@ namespace ClassicAssist.UI.ViewModels
 
         public EntityCollectionViewerViewModel( ItemCollection collection )
         {
-            Collection = collection;
             Options = LoadOptions();
 
-            Entities = new ObservableCollection<EntityCollectionData>( !Options.ShowChildItems
-                ? collection.ToEntityCollectionData( _sorter, _nameOverrides )
-                : new ItemCollection( collection.Serial ) { ItemCollection.GetAllItems( collection.GetItems() ) }.ToEntityCollectionData( _sorter, _nameOverrides ) );
+            // Build the display source once (flattened when showing child items) and keep it in
+            // Collection, so later sorting/filtering rebuild from the same source - consistent with
+            // Refresh. The real container is tracked separately (SetEventSource) for live updates.
+            Collection = !Options.ShowChildItems
+                ? collection
+                : new ItemCollection( collection.Serial ) { ItemCollection.GetAllItems( collection.GetItems() ) };
+
+            Entities = new ObservableCollection<EntityCollectionData>( Collection.ToEntityCollectionData( _sorter, _nameOverrides ) );
 
             SelectedItems.CollectionChanged += ( sender, args ) =>
             {
@@ -980,6 +984,40 @@ namespace ClassicAssist.UI.ViewModels
                 }
 
                 ecd.NotifyPropertiesUpdated();
+
+                // Names/properties arrive after the row was inserted, so under a property-derived
+                // sort (e.g. Name or Weight) the item may now be in the wrong place - move it.
+                if ( _sorter != null )
+                {
+                    int oldIndex = Entities.IndexOf( ecd );
+
+                    if ( oldIndex >= 0 )
+                    {
+                        int newIndex = 0;
+
+                        for ( int i = 0; i < Entities.Count; i++ )
+                        {
+                            if ( i == oldIndex )
+                            {
+                                continue;
+                            }
+
+                            if ( _sorter.Compare( Entities[i].Entity, ecd.Entity ) <= 0 )
+                            {
+                                newIndex++;
+                            }
+                            else
+                            {
+                                break;
+                            }
+                        }
+
+                        if ( newIndex != oldIndex )
+                        {
+                            Entities.Move( oldIndex, newIndex );
+                        }
+                    }
+                }
             } );
         }
 

--- a/ClassicAssist/UI/Views/Agents/AutolootTabControl.xaml
+++ b/ClassicAssist/UI/Views/Agents/AutolootTabControl.xaml
@@ -163,7 +163,7 @@
                                 <MenuItem Header="{x:Static resources:Strings.Move_to_group}"
                                           ItemsSource="{Binding Draggables}">
                                     <MenuItem.Style>
-                                        <Style TargetType="MenuItem">
+                                        <Style TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}">
                                             <Style.Triggers>
                                                 <DataTrigger Binding="{Binding SelectedItem}" Value="{x:Null}">
                                                     <Setter Property="Visibility" Value="Collapsed"/>
@@ -177,7 +177,7 @@
                                         </DataTemplate>
                                     </MenuItem.ItemTemplate>
                                     <MenuItem.ItemContainerStyle>
-                                        <Style TargetType="MenuItem">
+                                        <Style TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}">
                                             <Setter Property="Visibility"
                                                     Value="{Binding Converter={StaticResource DraggableGroupVisibilityConverter}}" />
                                             <Setter Property="Command"

--- a/ClassicAssist/UI/Views/Agents/DressTabControl.xaml
+++ b/ClassicAssist/UI/Views/Agents/DressTabControl.xaml
@@ -103,7 +103,7 @@
                     <ListBox.ContextMenu>
                         <ContextMenu>
                             <ContextMenu.Resources>
-                                <Style TargetType="MenuItem">
+                                <Style TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}">
                                     <Style.Triggers>
                                         <DataTrigger Binding="{Binding SelectedDressItem.Type}"
                                                      Value="{x:Static dress:DressAgentItemType.ID}">

--- a/ClassicAssist/UI/Views/ECV/ContextMenu.xaml
+++ b/ClassicAssist/UI/Views/ECV/ContextMenu.xaml
@@ -4,6 +4,8 @@
                     xmlns:viewModels="clr-namespace:ClassicAssist.UI.ViewModels"
                     xmlns:misc="clr-namespace:ClassicAssist.Misc">
     <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary
+            Source="pack://application:,,,/ClassicAssist.Shared;component/Resources/MenuStyles.xaml" />
         <ResourceDictionary>
             <misc:BindingProxy x:Key="Proxy" Data="{Binding}" />
             <ContextMenu x:Key="ContextMenu">
@@ -31,7 +33,7 @@
                         </Style>
                     </MenuItem.Style>
                     <MenuItem.ItemContainerStyle>
-                        <Style TargetType="MenuItem">
+                        <Style TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}">
                             <Setter Property="Header" Value="{Binding Name}" />
                             <Setter Property="Command"
                                     Value="{Binding Source={StaticResource Proxy}, Path=Data.(viewModels:EntityCollectionViewerViewModel.ContextMoveToSetCommand)}" />
@@ -93,7 +95,7 @@
                         </Style>
                     </MenuItem.Style>
                     <MenuItem.ItemContainerStyle>
-                        <Style TargetType="MenuItem">
+                        <Style TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}">
                             <Setter Property="Header" Value="{Binding Key}" />
                             <Setter Property="Command"
                                     Value="{Binding Source={StaticResource Proxy}, Path=Data.(viewModels:EntityCollectionViewerViewModel.ContextCustomActionCommand)}" />

--- a/ClassicAssist/UI/Views/ECV/Filter/EntityCollectionFilterControl.xaml
+++ b/ClassicAssist/UI/Views/ECV/Filter/EntityCollectionFilterControl.xaml
@@ -43,8 +43,23 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
-                    <!-- Boolean operation selector (hidden for first top-level group via style override) -->
+                    <!-- Boolean operation selector (hidden for first top-level group, where the operation has no effect) -->
                     <StackPanel Orientation="Horizontal" Grid.Row="0" x:Name="OperationPanel">
+                        <StackPanel.Style>
+                            <Style TargetType="{x:Type StackPanel}">
+                                <Setter Property="Visibility">
+                                    <Setter.Value>
+                                        <MultiBinding
+                                            Converter="{StaticResource CollectionIndexZeroVisibilityConverter}">
+                                            <Binding
+                                                Path="Data.(filter:EntityCollectionFilterViewModel.Item).Groups"
+                                                Source="{StaticResource DataContextProxy}" />
+                                            <Binding Path="." />
+                                        </MultiBinding>
+                                    </Setter.Value>
+                                </Setter>
+                            </Style>
+                        </StackPanel.Style>
                         <ComboBox ItemsSource="{misc1:EnumBindingSource {x:Type models:BooleanOperation}}"
                                   MinWidth="100"
                                   SelectedItem="{Binding Operation}" Margin="0,0,5,0" />

--- a/ClassicAssist/UI/Views/ECV/Filter/EntityCollectionFilterControl.xaml.cs
+++ b/ClassicAssist/UI/Views/ECV/Filter/EntityCollectionFilterControl.xaml.cs
@@ -17,6 +17,9 @@ namespace ClassicAssist.UI.Views.ECV.Filter
         public static readonly DependencyProperty AssembliesProperty = DependencyProperty.Register( nameof( Assemblies ), typeof( ObservableCollection<Assembly> ),
             typeof( EntityCollectionFilterControl ), new PropertyMetadata( new ObservableCollection<Assembly>(), PropertyChangedCallback ) );
 
+        public static readonly DependencyProperty IsFilterAppliedProperty = DependencyProperty.Register( nameof( IsFilterApplied ), typeof( bool ),
+            typeof( EntityCollectionFilterControl ), new PropertyMetadata( default( bool ), PropertyChangedCallback ) );
+
         public EntityCollectionFilterControl()
         {
             InitializeComponent();
@@ -34,6 +37,12 @@ namespace ClassicAssist.UI.Views.ECV.Filter
         {
             get => (ICommand) GetValue( CommandProperty );
             set => SetValue( CommandProperty, value );
+        }
+
+        public bool IsFilterApplied
+        {
+            get => (bool) GetValue( IsFilterAppliedProperty );
+            set => SetValue( IsFilterAppliedProperty, value );
         }
 
         private void OnIsVisibleChanged( object sender, DependencyPropertyChangedEventArgs e )
@@ -61,6 +70,11 @@ namespace ClassicAssist.UI.Views.ECV.Filter
                 case ICommand command:
                     viewModel.Command = command;
                     break;
+            }
+
+            if ( e.Property == IsFilterAppliedProperty )
+            {
+                viewModel.IsFilterApplied = (bool) e.NewValue;
             }
         }
     }

--- a/ClassicAssist/UI/Views/ECV/Filter/EntityCollectionFilterViewModel.cs
+++ b/ClassicAssist/UI/Views/ECV/Filter/EntityCollectionFilterViewModel.cs
@@ -272,9 +272,15 @@ namespace ClassicAssist.UI.Views.ECV.Filter
                 return;
             }
 
+            SetActiveProfile( entry );
+        }
+
+        // All profile transitions route through here so an applied filter is kept in sync with the
+        // active profile (switching, adding or removing a profile re-applies when a filter is live).
+        private void SetActiveProfile( EntityCollectionFilterEntry entry )
+        {
             SelectedProfile = Item = entry;
 
-            // If a filter is already applied, switching to another filter re-applies it immediately.
             if ( IsFilterApplied )
             {
                 Apply( null );
@@ -289,11 +295,12 @@ namespace ClassicAssist.UI.Views.ECV.Filter
 
             if ( Profiles.Count > 0 )
             {
-                SelectedProfile = Item = Profiles[0];
+                SetActiveProfile( Profiles[0] );
             }
             else
             {
                 AddDefaultEntry();
+                SetActiveProfile( Item );
             }
         }
 
@@ -312,7 +319,7 @@ namespace ClassicAssist.UI.Views.ECV.Filter
             };
 
             Profiles.Add( newProfile );
-            SelectedProfile = Item = newProfile;
+            SetActiveProfile( newProfile );
         }
 
         public void LoadFilterProfiles()

--- a/ClassicAssist/UI/Views/ECV/Filter/EntityCollectionFilterViewModel.cs
+++ b/ClassicAssist/UI/Views/ECV/Filter/EntityCollectionFilterViewModel.cs
@@ -219,6 +219,8 @@ namespace ClassicAssist.UI.Views.ECV.Filter
 
         public ICommand Command { get; set; }
 
+        public bool IsFilterApplied { get; set; }
+
         public ObservableCollection<PropertyEntry> Constraints
         {
             get => _constraints;
@@ -271,6 +273,12 @@ namespace ClassicAssist.UI.Views.ECV.Filter
             }
 
             SelectedProfile = Item = entry;
+
+            // If a filter is already applied, switching to another filter re-applies it immediately.
+            if ( IsFilterApplied )
+            {
+                Apply( null );
+            }
         }
 
         private void RemoveProfile( object obj )

--- a/ClassicAssist/UI/Views/EntityCollectionViewer.xaml
+++ b/ClassicAssist/UI/Views/EntityCollectionViewer.xaml
@@ -8,6 +8,7 @@
     xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
     xmlns:models="clr-namespace:ClassicAssist.UI.Models"
     xmlns:valueConverters="clr-namespace:ClassicAssist.Shared.UI.ValueConverters;assembly=ClassicAssist.Shared"
+    xmlns:converters="clr-namespace:ClassicAssist.UI.Misc.ValueConverters"
     xmlns:filter="clr-namespace:ClassicAssist.UI.Views.ECV.Filter"
     xmlns:ecv="clr-namespace:ClassicAssist.UI.Views.ECV"
     xmlns:local="clr-namespace:ClassicAssist.UI.Views"
@@ -32,6 +33,7 @@
             </ResourceDictionary.MergedDictionaries>
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
             <valueConverters:InverseBooleanToVisibilityConverter x:Key="InverseBooleanToVisibilityConverter" />
+            <converters:EnumMatchToBooleanConverter x:Key="EnumMatchToBooleanConverter" />
         </ResourceDictionary>
     </Window.Resources>
     <Grid>
@@ -83,25 +85,35 @@
                 <Image Source="{StaticResource ContainerIcon}" Height="19" />
             </Button>
             <Menu Background="Transparent" Height="24">
-                <MenuItem Height="24">
+                <!-- Explicit style refs: menu popup items don't reliably pick up the theme's
+                     implicit {x:Type MenuItem} style, so bind it at load in the window scope. -->
+                <MenuItem Height="24" Style="{StaticResource {x:Type MenuItem}}"
+                          ItemContainerStyle="{StaticResource {x:Type MenuItem}}">
                     <MenuItem.Header>
-                        <Image Source="{StaticResource SortIcon}" />
+                        <Image Source="{StaticResource SortIcon}" Height="19" Width="19" />
                     </MenuItem.Header>
-                    <MenuItem Header="{x:Static resources:Strings.Name}" Command="{Binding ChangeSortStyleCommand}"
+                    <MenuItem Header="{x:Static resources:Strings.Name}" IsCheckable="True"
+                              IsChecked="{Binding SortStyle, Mode=OneWay, Converter={StaticResource EnumMatchToBooleanConverter}, ConverterParameter={x:Static models:EntityCollectionSortStyle.Name}}"
+                              Command="{Binding ChangeSortStyleCommand}"
                               CommandParameter="{x:Static models:EntityCollectionSortStyle.Name}" />
-                    <MenuItem Header="{x:Static resources:Strings.Serial}"
+                    <MenuItem Header="{x:Static resources:Strings.Serial}" IsCheckable="True"
+                              IsChecked="{Binding SortStyle, Mode=OneWay, Converter={StaticResource EnumMatchToBooleanConverter}, ConverterParameter={x:Static models:EntityCollectionSortStyle.Serial}}"
                               Command="{Binding ChangeSortStyleCommand}"
                               CommandParameter="{x:Static models:EntityCollectionSortStyle.Serial}" />
-                    <MenuItem Header="{x:Static resources:Strings.Color}"
+                    <MenuItem Header="{x:Static resources:Strings.Color}" IsCheckable="True"
+                              IsChecked="{Binding SortStyle, Mode=OneWay, Converter={StaticResource EnumMatchToBooleanConverter}, ConverterParameter={x:Static models:EntityCollectionSortStyle.Hue}}"
                               Command="{Binding ChangeSortStyleCommand}"
                               CommandParameter="{x:Static models:EntityCollectionSortStyle.Hue}" />
-                    <MenuItem Header="{x:Static resources:Strings.Graphic}"
+                    <MenuItem Header="{x:Static resources:Strings.Graphic}" IsCheckable="True"
+                              IsChecked="{Binding SortStyle, Mode=OneWay, Converter={StaticResource EnumMatchToBooleanConverter}, ConverterParameter={x:Static models:EntityCollectionSortStyle.ID}}"
                               Command="{Binding ChangeSortStyleCommand}"
                               CommandParameter="{x:Static models:EntityCollectionSortStyle.ID}" />
-                    <MenuItem Header="{x:Static resources:Strings.Amount}"
+                    <MenuItem Header="{x:Static resources:Strings.Amount}" IsCheckable="True"
+                              IsChecked="{Binding SortStyle, Mode=OneWay, Converter={StaticResource EnumMatchToBooleanConverter}, ConverterParameter={x:Static models:EntityCollectionSortStyle.Quantity}}"
                               Command="{Binding ChangeSortStyleCommand}"
                               CommandParameter="{x:Static models:EntityCollectionSortStyle.Quantity}" />
-                    <MenuItem Header="{x:Static resources:Strings.Item_Weight}"
+                    <MenuItem Header="{x:Static resources:Strings.Item_Weight}" IsCheckable="True"
+                              IsChecked="{Binding SortStyle, Mode=OneWay, Converter={StaticResource EnumMatchToBooleanConverter}, ConverterParameter={x:Static models:EntityCollectionSortStyle.Weight}}"
                               Command="{Binding ChangeSortStyleCommand}"
                               CommandParameter="{x:Static models:EntityCollectionSortStyle.Weight}" />
                 </MenuItem>
@@ -158,6 +170,7 @@
                       VerticalScrollBarVisibility="Auto">
             <filter:EntityCollectionFilterControl MaxHeight="400"
                                                   Command="{Binding DataContext.ApplyFiltersCommand, ElementName=window}"
+                                                  IsFilterApplied="{Binding DataContext.IsFilterApplied, ElementName=window, Mode=OneWay}"
                                                   Assemblies="{Binding DataContext.Options.Assemblies, ElementName=window}" />
         </ScrollViewer>
         <Grid Grid.Row="2"

--- a/ClassicAssist/UI/Views/MacrosTabControl.xaml
+++ b/ClassicAssist/UI/Views/MacrosTabControl.xaml
@@ -157,7 +157,7 @@
                                     <MenuItem Header="{x:Static resources:Strings.Move_to_group}"
                                           ItemsSource="{Binding Draggables}">
                                         <MenuItem.Style>
-                                            <Style TargetType="MenuItem">
+                                            <Style TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}">
                                                 <Style.Triggers>
                                                     <DataTrigger Binding="{Binding SelectedItem}" Value="{x:Null}">
                                                         <Setter Property="Visibility" Value="Collapsed"/>
@@ -171,7 +171,7 @@
                                             </DataTemplate>
                                         </MenuItem.ItemTemplate>
                                         <MenuItem.ItemContainerStyle>
-                                            <Style TargetType="MenuItem">
+                                            <Style TargetType="MenuItem" BasedOn="{StaticResource {x:Type MenuItem}}">
                                                 <Setter Property="Visibility"
                                                     Value="{Binding Converter={StaticResource DraggableGroupVisibilityConverter}}" />
                                                 <Setter Property="Command"


### PR DESCRIPTION
Sort:
- Sort options are now checkable/toggleable; default is no order.
- The active sort is reapplied on refresh and live add/remove, instead of being lost as items stream in.

Filter:
- Disabling the filter toggle removes any applied filter.
- Switching profiles while a filter is applied auto-reapplies it.
- Restore hiding the boolean-operator selector for the first top-level group (regressed by the nested-groups change).

Menus:
- Add dark-themed default MenuItem / ContextMenu / menu Separator styles in a shared MenuStyles.xaml, merged into the theme and directly into standalone menu dictionaries so BasedOn/explicit refs resolve instead of falling back to the light system default (fixes white ECV context submenu and sort menu).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced dark theme menu styling, including separators and context menus.
  * Added selectable entity collection sorting with a “clear sort” option.
  * Added filter-applied state tracking, with automatic filter reapplication when profiles change.
* **Bug Fixes**
  * Newly added and updated entities now keep the active sort order.
  * Improved visibility logic for filter operation controls.
  * Standardised menu item styling inheritance across related context menus.
* **Documentation**
  * —
<!-- end of auto-generated comment: release notes by coderabbit.ai -->