### PR TITLE
Add ASCII prompt (0x9A) support for prompt macro commands

### DIFF
--- a/ClassicAssist/Data/Macros/Commands/MsgCommands.cs
+++ b/ClassicAssist/Data/Macros/Commands/MsgCommands.cs
@@ -1,7 +1,29 @@
-﻿using System;
+#region License
+
+// Copyright (C) 2026 Reetus
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#endregion
+
+using System;
 using System.IO;
+using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Assistant;
+using ClassicAssist.Misc;
 using ClassicAssist.Shared.Resources;
 using ClassicAssist.UO.Data;
 using ClassicAssist.UO.Network.PacketFilter;
@@ -47,60 +69,50 @@ namespace ClassicAssist.Data.Macros.Commands
             return hue == DERIVED_SPEAK_HUE ? GetSpeakHue() : hue;
         }
 
-        [CommandsDisplay( Category = nameof( Strings.Messages ),
-            Parameters = new[] { nameof( ParameterType.String ), nameof( ParameterType.Hue ) } )]
+        [CommandsDisplay( Category = nameof( Strings.Messages ), Parameters = new[] { nameof( ParameterType.String ), nameof( ParameterType.Hue ) } )]
         public static void Msg( string message, int hue = DERIVED_SPEAK_HUE )
         {
             UOC.Speak( message, ResolveSpeakHue( hue ) );
         }
 
-        [CommandsDisplay( Category = nameof( Strings.Messages ),
-            Parameters = new[] { nameof( ParameterType.String ) } )]
+        [CommandsDisplay( Category = nameof( Strings.Messages ), Parameters = new[] { nameof( ParameterType.String ) } )]
         public static void YellMsg( string message )
         {
             UOC.Speak( message, GetSpeakHue(), JournalSpeech.Yell );
         }
 
-        [CommandsDisplay( Category = nameof( Strings.Messages ),
-            Parameters = new[] { nameof( ParameterType.String ) } )]
+        [CommandsDisplay( Category = nameof( Strings.Messages ), Parameters = new[] { nameof( ParameterType.String ) } )]
         public static void WhisperMsg( string message )
         {
             UOC.Speak( message, GetSpeakHue(), JournalSpeech.Whisper );
         }
 
-        [CommandsDisplay( Category = nameof( Strings.Messages ),
-            Parameters = new[] { nameof( ParameterType.String ) } )]
+        [CommandsDisplay( Category = nameof( Strings.Messages ), Parameters = new[] { nameof( ParameterType.String ) } )]
         public static void EmoteMsg( string message )
         {
             UOC.Speak( message, GetSpeakHue(), JournalSpeech.Emote );
         }
 
-        [CommandsDisplay( Category = nameof( Strings.Messages ),
-            Parameters = new[] { nameof( ParameterType.String ) } )]
+        [CommandsDisplay( Category = nameof( Strings.Messages ), Parameters = new[] { nameof( ParameterType.String ) } )]
         public static void GuildMsg( string message )
         {
             UOC.Speak( message, GetSpeakHue(), JournalSpeech.Guild );
         }
 
-        [CommandsDisplay( Category = nameof( Strings.Messages ),
-            Parameters = new[] { nameof( ParameterType.String ) } )]
+        [CommandsDisplay( Category = nameof( Strings.Messages ), Parameters = new[] { nameof( ParameterType.String ) } )]
         public static void AllyMsg( string message )
         {
             UOC.Speak( message, GetSpeakHue(), JournalSpeech.Alliance );
         }
 
-        [CommandsDisplay( Category = nameof( Strings.Messages ),
-            Parameters = new[] { nameof( ParameterType.String ) } )]
+        [CommandsDisplay( Category = nameof( Strings.Messages ), Parameters = new[] { nameof( ParameterType.String ) } )]
         public static void PartyMsg( string message )
         {
             UOC.PartyMessage( message );
         }
 
         [CommandsDisplay( Category = nameof( Strings.Messages ),
-            Parameters = new[]
-            {
-                nameof( ParameterType.String ), nameof( ParameterType.SerialOrAlias ), nameof( ParameterType.Hue )
-            } )]
+            Parameters = new[] { nameof( ParameterType.String ), nameof( ParameterType.SerialOrAlias ), nameof( ParameterType.Hue ) } )]
         public static void HeadMsg( string message, object obj = null, int hue = DERIVED_SPEAK_HUE )
         {
             int serial = AliasCommands.ResolveSerial( obj );
@@ -108,16 +120,17 @@ namespace ClassicAssist.Data.Macros.Commands
             UOC.OverheadMessage( message, ResolveSpeakHue( hue ), serial );
         }
 
-        [CommandsDisplay( Category = nameof( Strings.Messages ),
-            Parameters = new[] { nameof( ParameterType.String ) } )]
+        [CommandsDisplay( Category = nameof( Strings.Messages ), Parameters = new[] { nameof( ParameterType.String ) } )]
         public static void PromptMsg( string message )
         {
-            Engine.SendPacketToServer( new UnicodePromptResponse( Engine.LastPromptSerial, Engine.LastPromptID,
-                message ) );
+            BasePacket packet = Engine.LastPromptType == 0
+                ? (BasePacket) new AsciiPromptResponse( Engine.LastPromptSerial, Engine.LastPromptID, message )
+                : new UnicodePromptResponse( Engine.LastPromptSerial, Engine.LastPromptID, message );
+
+            Engine.SendPacketToServer( packet );
         }
 
-        [CommandsDisplay( Category = nameof( Strings.Messages ),
-            Parameters = new[] { nameof( ParameterType.String ), nameof( ParameterType.Timeout ) } )]
+        [CommandsDisplay( Category = nameof( Strings.Messages ), Parameters = new[] { nameof( ParameterType.String ), nameof( ParameterType.Timeout ) } )]
         public static (bool Result, string Message) GetText( string prompt, int timeout = 30000 )
         {
             int id = new Random().Next();
@@ -130,11 +143,7 @@ namespace ClassicAssist.Data.Macros.Commands
             string message = string.Empty;
 
             Engine.AddSendPreFilter( new PacketFilterInfo( 0xC2,
-                new[]
-                {
-                    PacketFilterConditions.IntAtPositionCondition( id, 3 ),
-                    PacketFilterConditions.IntAtPositionCondition( id, 7 )
-                }, ( bytes, info ) =>
+                new[] { PacketFilterConditions.IntAtPositionCondition( id, 3 ), PacketFilterConditions.IntAtPositionCondition( id, 7 ) }, ( bytes, info ) =>
                 {
                     PacketReader pr = new PacketReader( bytes, bytes.Length, false );
                     pr.Seek( 16, SeekOrigin.Current );
@@ -152,34 +161,46 @@ namespace ClassicAssist.Data.Macros.Commands
             return ( result, message );
         }
 
-        [CommandsDisplay( Category = nameof( Strings.Messages ),
-            Parameters = new[] { nameof( ParameterType.Timeout ) } )]
+        [CommandsDisplay( Category = nameof( Strings.Messages ), Parameters = new[] { nameof( ParameterType.Timeout ) } )]
         public static bool WaitForPrompt( int timeout )
         {
-            PacketFilterInfo pfi = new PacketFilterInfo( 0xC2 );
+            PacketFilterInfo[] pfis = {
+                new PacketFilterInfo( 0xC2 ),
+                new PacketFilterInfo( 0x9A )
+            };
 
-            PacketWaitEntry packetWaitEntry = Engine.PacketWaitEntries.Add( pfi, PacketDirection.Incoming, true );
+            PacketWaitEntry[] packetWaitEntries = pfis.Select( pfi => Engine.PacketWaitEntries.Add( pfi, PacketDirection.Incoming, true ) ).ToArray();
+
+            Task timeoutTask = Task.Delay( timeout );
+
+            Task[] tasks = packetWaitEntries.Select( pwe => pwe.Lock.ToTask() ).Append( timeoutTask ).ToArray();
 
             try
             {
-                bool result = packetWaitEntry.Lock.WaitOne( timeout );
+                int index = Task.WaitAny( tasks );
 
-                return result;
+                return index != tasks.Length -1;
             }
             finally
             {
-                Engine.PacketWaitEntries.Remove( packetWaitEntry );
+                foreach ( PacketWaitEntry pwe in packetWaitEntries )
+                {
+                    Engine.PacketWaitEntries.Remove( pwe );
+                }
             }
         }
 
         [CommandsDisplay( Category = nameof( Strings.Messages ) )]
         public static void CancelPrompt()
         {
-            Engine.SendPacketToServer( new UnicodePromptCancel( Engine.LastPromptSerial, Engine.LastPromptID ) );
+            BasePacket packet = Engine.LastPromptType == 0
+                ? (BasePacket) new AsciiPromptCancel( Engine.LastPromptSerial, Engine.LastPromptID )
+                : new UnicodePromptCancel( Engine.LastPromptSerial, Engine.LastPromptID );
+
+            Engine.SendPacketToServer( packet );
         }
 
-        [CommandsDisplay( Category = nameof( Strings.Messages ),
-            Parameters = new[] { nameof( ParameterType.String ) } )]
+        [CommandsDisplay( Category = nameof( Strings.Messages ), Parameters = new[] { nameof( ParameterType.String ) } )]
         public static void ChatMsg( string message )
         {
             UOC.ChatMsg( message );

--- a/ClassicAssist/Engine.cs
+++ b/ClassicAssist/Engine.cs
@@ -149,6 +149,7 @@ namespace Assistant
         public static DateTime LastMoveRequested { get; set; }
         public static int LastPromptID { get; set; }
         public static int LastPromptSerial { get; set; }
+        public static int LastPromptType { get; set; }
         public static DateTime LastSkillTime { get; set; }
 
         public static TargetQueue<TargetQueueObject> LastTargetQueue { get; set; } = new TargetQueue<TargetQueueObject>();

--- a/ClassicAssist/UO/Network/IncomingPacketHandlers.cs
+++ b/ClassicAssist/UO/Network/IncomingPacketHandlers.cs
@@ -122,6 +122,7 @@ namespace ClassicAssist.UO.Network
             Register( 0x77, 17, OnMobileMoving );
             Register( 0x7C, 0, OnDisplayItemListMenu );
             Register( 0x78, 0, OnMobileIncoming );
+            Register( 0x9A, 0, OnAsciiPrompt );
             Register( 0x98, 0, OnMobileName );
             Register( 0x99, 30, OnTarget );
             Register( 0x9E, 0, OnShopSell );
@@ -154,6 +155,16 @@ namespace ClassicAssist.UO.Network
             RegisterExtended( 0x21, 0, OnClearWeaponAbility );
             RegisterExtended( 0x25, 0, OnToggleSpecialMoves );
             RegisterExtended( 0x26, 0, OnMovementSpeed );
+        }
+
+        private static void OnAsciiPrompt( PacketReader reader )
+        {
+            int senderSerial = reader.ReadInt32();
+            int promptId = reader.ReadInt32();
+
+            Engine.LastPromptSerial = senderSerial;
+            Engine.LastPromptID = promptId;
+            Engine.LastPromptType = 0;
         }
 
         private static void OnDeathAnimation( PacketReader reader )
@@ -679,6 +690,7 @@ namespace ClassicAssist.UO.Network
 
             Engine.LastPromptSerial = senderSerial;
             Engine.LastPromptID = promptId;
+            Engine.LastPromptType = 1;
         }
 
         private static void OnShopSell( PacketReader reader )

--- a/ClassicAssist/UO/Network/Packets/AsciiPromptCancel.cs
+++ b/ClassicAssist/UO/Network/Packets/AsciiPromptCancel.cs
@@ -1,0 +1,53 @@
+﻿#region License
+// Copyright (C) 2026 Reetus
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#endregion
+
+using ClassicAssist.Shared.Resources;
+using ClassicAssist.UO.Data;
+using ClassicAssist.UO.Network.PacketFilter;
+
+namespace ClassicAssist.UO.Network.Packets
+{
+    public class AsciiPromptCancel : BasePacket, IMacroCommandParser
+    {
+        public AsciiPromptCancel()
+        {
+            
+        }
+
+        public AsciiPromptCancel( int senderSerial, int promptId )
+        {
+            _writer = new PacketWriter( 15 );
+            _writer.Write( (byte) 0x9A );
+            _writer.Write( (short) 15 );
+            _writer.Write( senderSerial );
+            _writer.Write( promptId );
+            _writer.Write( 0 );
+            _writer.Fill();
+
+        }
+
+        public string Parse( byte[] packet, int length, PacketDirection direction )
+        {
+            if ( packet[0] != 0x9A || direction != PacketDirection.Outgoing )
+            {
+                return null;
+            }
+
+            return packet[14] != 0x00 ? null : "CancelPrompt()\r\n";
+        }
+    }
+}

--- a/ClassicAssist/UO/Network/Packets/AsciiPromptResponse.cs
+++ b/ClassicAssist/UO/Network/Packets/AsciiPromptResponse.cs
@@ -1,0 +1,64 @@
+﻿#region License
+
+// Copyright (C) 2026 Reetus
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#endregion
+
+using System.Text;
+using ClassicAssist.UO.Data;
+using ClassicAssist.UO.Network.PacketFilter;
+
+namespace ClassicAssist.UO.Network.Packets
+{
+    public class AsciiPromptResponse : BasePacket, IMacroCommandParser
+    {
+        public AsciiPromptResponse()
+        {
+        }
+
+        public AsciiPromptResponse( int senderSerial, int promptId, string text )
+        {
+            byte[] textBytes = Encoding.ASCII.GetBytes( text + '\0' );
+
+            int len = 15 + textBytes.Length;
+
+            _writer = new PacketWriter( len );
+            _writer.Write( (byte) 0x9A );
+            _writer.Write( (short) len );
+            _writer.Write( senderSerial );
+            _writer.Write( promptId );
+            _writer.Write( 1 );
+            _writer.Write( textBytes, 0, textBytes.Length );
+        }
+
+        public string Parse( byte[] packet, int length, PacketDirection direction )
+        {
+            if ( packet[0] != 0x9A || direction != PacketDirection.Outgoing )
+            {
+                return null;
+            }
+
+            if ( packet[14] == 0x00 )
+            {
+                return null;
+            }
+
+            string text = Encoding.ASCII.GetString( packet, 15, packet.Length - 15 ).Trim( '\0' );
+
+            return $"PromptMsg(\"{text}\")\r\n";
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Servers can request text input via either the **ASCII prompt (0x9A)** or the **Unicode prompt (0xC2)**. Previously only the Unicode prompt was handled, so:

- `PromptMsg` / `CancelPrompt` always sent the Unicode packet, which is ignored/rejected when the server issued an ASCII prompt.
- `WaitForPrompt` only waited on `0xC2`, so it never woke for an ASCII prompt.

This adds ASCII prompt support alongside the existing Unicode path.

## Changes

- **Engine:** track the incoming prompt type in `Engine.LastPromptType` (set from the `0x9A` and `0xC2` incoming handlers).
- **Packets:** new `AsciiPromptResponse` and `AsciiPromptCancel` (0x9A) packets, each implementing `IMacroCommandParser` so recorded outgoing prompts map back to `PromptMsg(...)` / `CancelPrompt()`.
- **IncomingPacketHandlers:** register a handler for `0x9A` that records the prompt serial/id and sets the type.
- **MsgCommands:**
  - `PromptMsg` and `CancelPrompt` now send the packet matching the last prompt type (ASCII vs Unicode).
  - `WaitForPrompt` now waits on both `0xC2` and `0x9A` (via `Task.WaitAny` across both wait entries).

## Testing

- `dotnet build` succeeds.
- Manual in-client verification against a shard that issues ASCII prompts still recommended (e.g. certain NPC/context text prompts): `PromptMsg`, `CancelPrompt`, and `WaitForPrompt` behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)