### PR TITLE
Add WaitForRemoveObject macro command

### DIFF
--- a/ClassicAssist.Tests/MacroCommands/EntityCommandTests.cs
+++ b/ClassicAssist.Tests/MacroCommands/EntityCommandTests.cs
@@ -1,0 +1,135 @@
+using Assistant;
+using ClassicAssist.Data.Macros.Commands;
+using ClassicAssist.UO.Network.PacketFilter;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ClassicAssist.Tests.MacroCommands
+{
+    /// <summary>
+    ///     <see cref="EntityCommands.WaitForRemoveObject" /> waits on the 0x1D remove object packet, matched
+    ///     on the serial at offset 1. Its default timeout is -1, so anything that stops it from matching
+    ///     hangs the macro rather than returning False - hence the unknown-alias and wrong-serial cases.
+    /// </summary>
+    [TestClass]
+    public class EntityCommandTests
+    {
+        private const int SERIAL = 0x40000001;
+
+        [TestMethod]
+        public void WillWaitForRemoveObject()
+        {
+            Assert.IsTrue( RunWaitForRemoveObject( SERIAL, 1000, SERIAL ) );
+        }
+
+        /// <summary>
+        ///     The default timeout is infinite, so this only returns because the packet arrives.
+        /// </summary>
+        [TestMethod]
+        public void WillWaitForRemoveObjectWithNoTimeout()
+        {
+            Engine.PacketWaitEntries = new PacketWaitEntries();
+
+            void OnWaitEntryAddedEvent( PacketWaitEntry entry )
+            {
+                byte[] packet = { 0x1D, 0x40, 0x00, 0x00, 0x01 };
+
+                Engine.PacketWaitEntries.CheckWait( packet, PacketDirection.Incoming );
+            }
+
+            Engine.PacketWaitEntries.WaitEntryAddedEvent += OnWaitEntryAddedEvent;
+
+            try
+            {
+                Assert.IsTrue( EntityCommands.WaitForRemoveObject( SERIAL ) );
+            }
+            finally
+            {
+                Engine.PacketWaitEntries.WaitEntryAddedEvent -= OnWaitEntryAddedEvent;
+            }
+        }
+
+        [TestMethod]
+        public void WillResolveAlias()
+        {
+            AliasCommands.SetAlias( "removeobjecttest", SERIAL );
+
+            try
+            {
+                Assert.IsTrue( RunWaitForRemoveObject( "removeobjecttest", 1000, SERIAL ) );
+            }
+            finally
+            {
+                AliasCommands.UnsetAlias( "removeobjecttest" );
+            }
+        }
+
+        [TestMethod]
+        public void WillNotWaitForRemoveObjectOfDifferentSerial()
+        {
+            Assert.IsFalse( RunWaitForRemoveObject( SERIAL, 100, 0x40000002 ) );
+        }
+
+        [TestMethod]
+        public void WillTimeoutWithNoRemoveObject()
+        {
+            Assert.IsFalse( RunWaitForRemoveObject( SERIAL, 100, null ) );
+        }
+
+        /// <summary>
+        ///     An unknown alias resolves to -1, which must not become a wait on serial 0xFFFFFFFF.
+        /// </summary>
+        [TestMethod]
+        public void WillNotWaitForUnknownAlias()
+        {
+            Engine.PacketWaitEntries = new PacketWaitEntries();
+
+            Assert.IsFalse( EntityCommands.WaitForRemoveObject( "notanalias" ) );
+            Assert.AreEqual( 0, Engine.PacketWaitEntries.GetEntries().Length );
+        }
+
+        /// <summary>
+        ///     A timed-out entry is never matched, so nothing else removes it.
+        /// </summary>
+        [TestMethod]
+        public void WillRemoveWaitEntryOnTimeout()
+        {
+            RunWaitForRemoveObject( SERIAL, 100, null );
+
+            Assert.AreEqual( 0, Engine.PacketWaitEntries.GetEntries().Length );
+        }
+
+        /// <summary>
+        ///     Runs the command and satisfies it with a 0x1D naming <paramref name="removedSerial" />, or with
+        ///     nothing at all when it is null.
+        /// </summary>
+        private static bool RunWaitForRemoveObject( object obj, int timeout, int? removedSerial )
+        {
+            Engine.PacketWaitEntries = new PacketWaitEntries();
+
+            void OnWaitEntryAddedEvent( PacketWaitEntry entry )
+            {
+                if ( removedSerial == null )
+                {
+                    return;
+                }
+
+                int serial = removedSerial.Value;
+
+                byte[] packet = { 0x1D, (byte) ( serial >> 24 ), (byte) ( serial >> 16 ), (byte) ( serial >> 8 ), (byte) serial };
+
+                Engine.PacketWaitEntries.CheckWait( packet, PacketDirection.Incoming );
+            }
+
+            Engine.PacketWaitEntries.WaitEntryAddedEvent += OnWaitEntryAddedEvent;
+
+            try
+            {
+                return EntityCommands.WaitForRemoveObject( obj, timeout );
+            }
+            finally
+            {
+                Engine.PacketWaitEntries.WaitEntryAddedEvent -= OnWaitEntryAddedEvent;
+            }
+        }
+    }
+}

--- a/ClassicAssist/Data/Macros/Commands/EntityCommands.cs
+++ b/ClassicAssist/Data/Macros/Commands/EntityCommands.cs
@@ -246,6 +246,39 @@ namespace ClassicAssist.Data.Macros.Commands
             return pwe.Lock.WaitOne( timeout );
         }
 
+        /// <summary>
+        ///     Waits on the 0x1D remove object packet for <paramref name="obj" />, i.e. the server telling the
+        ///     client the entity has gone out of view or been deleted. Defaults to no timeout - the macro thread
+        ///     blocks until the packet arrives or the macro is stopped.
+        /// </summary>
+        [CommandsDisplay( Category = nameof( Strings.Entity ), Parameters = new[] { nameof( ParameterType.SerialOrAlias ), nameof( ParameterType.Timeout ) } )]
+        public static bool WaitForRemoveObject( object obj, int timeout = -1 )
+        {
+            // <= 0 rather than == 0: an unknown alias resolves to -1, and with no timeout by default that
+            // would otherwise wait forever on a serial the server will never send.
+            int serial = AliasCommands.ResolveSerial( obj );
+
+            if ( serial <= 0 )
+            {
+                UOC.SystemMessage( Strings.Invalid_or_unknown_object_id );
+
+                return false;
+            }
+
+            PacketFilterInfo pfi = new PacketFilterInfo( 0x1D, new[] { PacketFilterConditions.IntAtPositionCondition( serial, 1 ) } );
+
+            PacketWaitEntry pwe = Engine.PacketWaitEntries.Add( pfi, PacketDirection.Incoming, true );
+
+            try
+            {
+                return pwe.Lock.WaitOne( timeout );
+            }
+            finally
+            {
+                Engine.PacketWaitEntries.Remove( pwe );
+            }
+        }
+
         [CommandsDisplay( Category = nameof( Strings.Entity ), Parameters = new[] { nameof( ParameterType.BuffName ) } )]
         public static double BuffTime( string name )
         {

--- a/ClassicAssist/Resources/MacroCommandHelp.Designer.cs
+++ b/ClassicAssist/Resources/MacroCommandHelp.Designer.cs
@@ -4971,6 +4971,35 @@ namespace ClassicAssist.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Returns True if the given object is removed before the timeout, else False, -1 for infinite (default).
+        /// </summary>
+        public static string WAITFORREMOVEOBJECT_COMMAND_DESCRIPTION {
+            get {
+                return ResourceManager.GetString("WAITFORREMOVEOBJECT_COMMAND_DESCRIPTION", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to if FindType(&apos;0x0f0e&apos;):
+        ///    UseObject(&apos;found&apos;)
+        ///    WaitForRemoveObject(&apos;found&apos;, 5000).
+        /// </summary>
+        public static string WAITFORREMOVEOBJECT_COMMAND_EXAMPLE {
+            get {
+                return ResourceManager.GetString("WAITFORREMOVEOBJECT_COMMAND_EXAMPLE", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to WaitForRemoveObject(&apos;found&apos;).
+        /// </summary>
+        public static string WAITFORREMOVEOBJECT_COMMAND_INSERTTEXT {
+            get {
+                return ResourceManager.GetString("WAITFORREMOVEOBJECT_COMMAND_INSERTTEXT", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Wait for target packet from server, optional timeout parameter (default 5000 milliseconds)..
         /// </summary>
         public static string WAITFORTARGET_COMMAND_DESCRIPTION {

--- a/ClassicAssist/Resources/MacroCommandHelp.resx
+++ b/ClassicAssist/Resources/MacroCommandHelp.resx
@@ -1966,4 +1966,15 @@ if FindType(0xe79, -1, 'backpack'):
   <data name="WAITFORBUFFDISABLED_COMMAND_INSERTTEXT" xml:space="preserve">
     <value>WaitForBuffDisabled('Active Meditation', 5000)</value>
   </data>
+  <data name="WAITFORREMOVEOBJECT_COMMAND_DESCRIPTION" xml:space="preserve">
+    <value>Returns True if the given object is removed before the timeout, else False, -1 for infinite (default)</value>
+  </data>
+  <data name="WAITFORREMOVEOBJECT_COMMAND_INSERTTEXT" xml:space="preserve">
+    <value>WaitForRemoveObject('found')</value>
+  </data>
+  <data name="WAITFORREMOVEOBJECT_COMMAND_EXAMPLE" xml:space="preserve">
+    <value>if FindType('0x0f0e'):
+    UseObject('found')
+    WaitForRemoveObject('found', 5000)</value>
+  </data>
 </root>


### PR DESCRIPTION
Waits on the incoming 0x1D remove object packet for a given serial or alias, i.e. the server telling the client the entity has gone out of view or been deleted.

```python
if FindType('0x0f0e'):
    UseObject('found')
    WaitForRemoveObject('found', 5000)
```

Unlike the other `WaitFor*` commands the default timeout is `-1`, so it blocks until the packet arrives or the macro is stopped. That is safe: `MacroInvoker.Stop` interrupts the macro thread, and a thread blocked in `WaitOne(-1)` is in `WaitSleepJoin`, so the resulting `ThreadInterruptedException` unwinds it — already caught there.

Two things differ from the `WaitForBuffEnabled`/`WaitForBuffDisabled` pair it is modelled on, both because of that infinite default:

- The serial guard is `<= 0` rather than `== 0`. `ResolveSerial` returns `-1` for an unknown alias, which would otherwise arm a wait on serial `0xFFFFFFFF` and hang for good. `MobileCommands` and `TargetCommands` already use `<= 0`.
- The wait is wrapped in try/finally so the entry is removed on timeout. `AutoRemove` only fires on a match, so a timed-out entry is otherwise left in the list forever. `WaitForBuffState` has this leak; not propagating it here.

Kept as a pure packet wait: no short-circuit for an entity already absent from `Engine.Items`/`Engine.Mobiles`. `UseObject` followed by `WaitForRemoveObject` on an already-consumed item will therefore block until the macro is stopped.

## Tests

New `EntityCommandTests` covers match, alias resolution, the infinite-timeout path, wrong serial, timeout, unknown alias, and entry cleanup on timeout — 7/7 pass. `TranslationTests`, `MacroTests` and `MacrosViewModelTests` also pass; the latter confirm the command's `CommandsDisplayAttribute` constructs, i.e. it actually loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a macro command that waits for a specified entity to be removed.
  * Supports entity serials and aliases, optional timeouts, and indefinite waiting.
  * Added in-app help, insertion text, and usage examples for the command.

* **Bug Fixes**
  * Ensures waits complete only for the matching entity and clean up correctly after completion or timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->