### PR TITLE
Make Object Inspector windows modeless

### DIFF
--- a/ClassicAssist/Data/Macros/Commands/MainCommands.cs
+++ b/ClassicAssist/Data/Macros/Commands/MainCommands.cs
@@ -119,7 +119,7 @@ namespace ClassicAssist.Data.Macros.Commands
                 ObjectInspectorWindow window =
                     new ObjectInspectorWindow { DataContext = new ObjectInspectorViewModel( entity ) };
 
-                window.ShowDialog();
+                window.Show();
             } ) );
         }
 

--- a/ClassicAssist/UI/ViewModels/ObjectInspectorViewModel.cs
+++ b/ClassicAssist/UI/ViewModels/ObjectInspectorViewModel.cs
@@ -456,7 +456,8 @@ namespace ClassicAssist.UI.ViewModels
             {
                 DataContext = new ObjectInspectorViewModel( entity ), Topmost = true
             };
-            window.ShowDialog();
+
+            window.Show();
         }
 
         private static void ShowItemCollection( ItemCollection collection )
@@ -471,7 +472,7 @@ namespace ClassicAssist.UI.ViewModels
                 DataContext = new EntityCollectionViewerViewModel( collection ), Topmost = true
             };
 
-            window.ShowDialog();
+            window.Show();
         }
     }
 

--- a/ClassicAssist/UI/Views/Macros/MacrosDebuggerControl.xaml.cs
+++ b/ClassicAssist/UI/Views/Macros/MacrosDebuggerControl.xaml.cs
@@ -100,7 +100,7 @@ namespace ClassicAssist.UI.Views.Macros
                 ObjectInspectorWindow window =
                     new ObjectInspectorWindow { DataContext = new ObjectInspectorViewModel( entity ) };
 
-                window.ShowDialog();
+                window.Show();
             } ) );
 
             return Task.CompletedTask;

--- a/ClassicAssist/UO/Commands.cs
+++ b/ClassicAssist/UO/Commands.cs
@@ -1025,7 +1025,7 @@ namespace ClassicAssist.UO
                     ObjectInspectorWindow window =
                         new ObjectInspectorWindow { DataContext = new ObjectInspectorViewModel( entity ) };
 
-                    window.ShowDialog();
+                    window.Show();
                 } ) );
             }
             else
@@ -1045,7 +1045,7 @@ namespace ClassicAssist.UO
                             DataContext = new ObjectInspectorViewModel( landTile )
                         };
 
-                        window.ShowDialog();
+                        window.Show();
                     } ) );
                 }
                 else
@@ -1069,7 +1069,7 @@ namespace ClassicAssist.UO
                             DataContext = new ObjectInspectorViewModel( selectedStatic )
                         };
 
-                        window.ShowDialog();
+                        window.Show();
                     } ) );
                 }
             }


### PR DESCRIPTION
## Problem

`ShowDialog()` is application-modal against every window on the same thread, so an open Object Inspector disabled the main window and any Entity Collection Viewer until it was closed.

The ECV -> inspector path already used `Show()`, but it was still blocked whenever an inspector had been opened from one of the other paths, and the inspector''s own nested windows were modal too.

## Changes

`ShowDialog()` -> `Show()` at every `ObjectInspectorWindow` call site:

- `UO/Commands.cs` - target-based inspect (entity, land tile, static tile); also the path used by the Object Inspector hotkey
- `Data/Macros/Commands/MainCommands.cs` - the `InspectObject` macro command
- `UI/Views/Macros/MacrosDebuggerControl.xaml.cs` - double-click a variable in the macro debugger
- `UI/ViewModels/ObjectInspectorViewModel.cs` - nested inspector from double-clicking a serial property, and the Entity Collection Viewer opened from a container property

The ECV settings window (`EntityCollectionViewerViewModel.Configure`) keeps `ShowDialog()` - it is a genuine settings dialog that saves options on close.

No `Owner` was ever set on these windows, so nothing else needed changing. They are already `Topmost=True` in XAML, and WPF keeps modeless windows alive via `Application.Current.Windows` even though the local variable falls out of scope.

## Testing

Compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Object inspection windows now open without blocking the main application.
  * You can continue using ClassicAssist while inspecting objects, items, entities and tiles.
  * Multiple inspection windows can remain open simultaneously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->