### PR TITLE
Fix launcher crash on exit

### DIFF
--- a/ClassicAssist.Shared/ClassicAssist.Shared.csproj
+++ b/ClassicAssist.Shared/ClassicAssist.Shared.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="AvalonEdit" Version="6.3.0.90" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="semver" Version="3.0.0" />
   </ItemGroup>
 

--- a/ClassicAssist.Updater/ClassicAssist.Updater.csproj
+++ b/ClassicAssist.Updater/ClassicAssist.Updater.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Exceptionless" Version="6.0.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />
     <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/ClassicAssist/ClassicAssist.csproj
+++ b/ClassicAssist/ClassicAssist.csproj
@@ -70,7 +70,7 @@
     <PackageReference Include="LiteDB" Version="5.0.21" />
     <PackageReference Include="MegaApiClient" Version="1.10.4" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.66.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Octokit" Version="13.0.1" />
     <PackageReference Include="OptimizedPriorityQueue" Version="5.1.0" />
     <PackageReference Include="Sentry" Version="4.13.0" />


### PR DESCRIPTION
Align Newtonsoft.Json to 13.0.4 across all projects. The launcher calls JToken.WriteTo(JsonWriter), an overload added in 13.0.4, but the shared output shipped 13.0.3 from the other projects, causing a MissingMethodException when closing the launcher.