### PR TITLE
Add MCP server for AI macro control

### DIFF
--- a/ClassicAssist.Shared/Resources/Strings.Designer.cs
+++ b/ClassicAssist.Shared/Resources/Strings.Designer.cs
@@ -6024,6 +6024,24 @@ namespace ClassicAssist.Shared.Resources {
             }
         }
 
+        public static string MCP {
+            get {
+                return ResourceManager.GetString("MCP", resourceCulture);
+            }
+        }
+
+        public static string MCP_tooltip {
+            get {
+                return ResourceManager.GetString("MCP tooltip", resourceCulture);
+            }
+        }
+
+        public static string MCP_invalid_port {
+            get {
+                return ResourceManager.GetString("MCP invalid port", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Use Right Hand.
         /// </summary>

--- a/ClassicAssist.Shared/Resources/Strings.resx
+++ b/ClassicAssist.Shared/Resources/Strings.resx
@@ -868,6 +868,15 @@
   <data name="Debug adapter invalid port" xml:space="preserve">
     <value>The debug adapter port must be between 1 and 65535.</value>
   </data>
+  <data name="MCP" xml:space="preserve">
+    <value>MCP server (AI agents)</value>
+  </data>
+  <data name="MCP tooltip" xml:space="preserve">
+    <value>Exposes a Model Context Protocol (MCP) server on localhost so AI agents can list, create, edit and run macros. Session-only, not saved to the profile.</value>
+  </data>
+  <data name="MCP invalid port" xml:space="preserve">
+    <value>The MCP server port must be between 1 and 65535.</value>
+  </data>
   <data name="Use Right Hand" xml:space="preserve">
     <value>Use Right Hand</value>
   </data>

--- a/ClassicAssist/Data/Options.cs
+++ b/ClassicAssist/Data/Options.cs
@@ -103,6 +103,8 @@ namespace ClassicAssist.Data
         private int _selectedTabIndexAgents;
         private bool _debugAdapterEnabled;
         private int _debugAdapterPort = 4712;
+        private bool _mcpEnabled;
+        private int _mcpPort = 4713;
 
         public bool AbilitiesGump
         {
@@ -445,6 +447,20 @@ namespace ClassicAssist.Data
         {
             get => _debugAdapterPort;
             set => SetProperty( ref _debugAdapterPort, value );
+        }
+
+        // Session-only: intentionally not persisted to the profile so multiple ClassicAssist
+        // instances don't fight over the same port on load. Enabled/port reset each session.
+        public bool McpEnabled
+        {
+            get => _mcpEnabled;
+            set => SetProperty( ref _mcpEnabled, value );
+        }
+
+        public int McpPort
+        {
+            get => _mcpPort;
+            set => SetProperty( ref _mcpPort, value );
         }
 
         public bool PreventAttackingFriendsInWarMode

--- a/ClassicAssist/Mcp/McpAgentTools.cs
+++ b/ClassicAssist/Mcp/McpAgentTools.cs
@@ -1,0 +1,354 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Assistant;
+using ClassicAssist.Data;
+using ClassicAssist.Data.Autoloot;
+using ClassicAssist.Data.Dress;
+using ClassicAssist.Data.Friends;
+using ClassicAssist.Data.Organizer;
+using ClassicAssist.Data.Scavenger;
+using ClassicAssist.Data.TrapPouch;
+using ClassicAssist.Data.Vendors;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace ClassicAssist.Mcp
+{
+    public static class McpAgentTools
+    {
+        private static readonly string[] _agents = { "dress", "organizer", "friends", "vendorbuy", "scavenger", "trappouch", "autoloot" };
+
+        public static IReadOnlyList<McpTool> GetTools()
+        {
+            return new List<McpTool>
+            {
+                new McpTool
+                {
+                    Name = "listAgents",
+                    Description = "List the agents (dress, organizer, friends, vendor buy, scavenger, trap pouch, autoloot) with their entry counts.",
+                    InputSchema = McpTools.ObjectSchema()
+                },
+                new McpTool
+                {
+                    Name = "getAgent",
+                    Description = "Get the current entries of an agent so you can query them (e.g. check if a mobile serial is on the friends list). Agents: dress, organizer, friends, vendorbuy, scavenger, trappouch, autoloot.",
+                    InputSchema = McpTools.ObjectSchema(
+                        new JObject
+                        {
+                            ["agent"] = McpTools.StringProperty( "The agent name (dress, organizer, friends, vendorbuy, scavenger, trappouch, autoloot)." ),
+                            ["filter"] = McpTools.StringProperty( "Optional case-insensitive substring to match entry name or serial (e.g. '0x006ec0dc')." )
+                        }, "agent" )
+                }
+            };
+        }
+
+        public static CallToolResult Invoke( string name, JObject args )
+        {
+            try
+            {
+                switch ( name )
+                {
+                    case "listAgents":
+                        return McpTools.Text( ListAgents() );
+                    case "getAgent":
+                        return McpTools.Text( GetAgent( McpTools.RequireString( args, "agent" ), McpTools.GetString( args, "filter" ) ) );
+                    default:
+                        return null;
+                }
+            }
+            catch ( Exception e )
+            {
+                return McpTools.Error( e.Message );
+            }
+        }
+
+        private static string ListAgents()
+        {
+            JArray array = new JArray();
+
+            foreach ( string agent in _agents )
+            {
+                int count = OnUi( () => GetEntryCount( agent ) );
+
+                array.Add( new JObject { ["agent"] = agent, ["entryCount"] = count } );
+            }
+
+            JObject result = new JObject
+            {
+                ["agents"] = array
+            };
+
+            return JsonConvert.SerializeObject( result, Formatting.Indented );
+        }
+
+        private static string GetAgent( string agent, string filter )
+        {
+            agent = Normalize( agent );
+
+            if ( !_agents.Contains( agent ) )
+            {
+                throw new InvalidOperationException(
+                    $"Unknown agent '{agent}'. Expected one of: {string.Join( ", ", _agents )}." );
+            }
+
+            JArray entries = OnUi( () => GetEntries( agent, filter ) );
+
+            JObject result = new JObject
+            {
+                ["agent"] = agent,
+                ["entryCount"] = entries.Count,
+                ["entries"] = entries
+            };
+
+            return JsonConvert.SerializeObject( result, Formatting.Indented );
+        }
+
+        private static int GetEntryCount( string agent )
+        {
+            return GetEntries( agent, null ).Count;
+        }
+
+        private static JArray GetEntries( string agent, string filter )
+        {
+            JArray array = new JArray();
+
+            bool Match( JObject entry )
+            {
+                if ( string.IsNullOrEmpty( filter ) )
+                {
+                    return true;
+                }
+
+                string name = entry["name"]?.ToObject<string>() ?? "";
+                string serial = entry["serial"]?.ToObject<string>() ?? "";
+
+                return name.IndexOf( filter, StringComparison.OrdinalIgnoreCase ) >= 0 ||
+                       serial.IndexOf( filter, StringComparison.OrdinalIgnoreCase ) >= 0;
+            }
+
+            switch ( agent )
+            {
+                case "friends":
+                {
+                    foreach ( FriendEntry entry in Options.CurrentOptions.Friends ?? Enumerable.Empty<FriendEntry>() )
+                    {
+                        JObject o = new JObject
+                        {
+                            ["name"] = entry.Name,
+                            ["serial"] = $"0x{entry.Serial:x8}"
+                        };
+
+                        if ( Match( o ) )
+                        {
+                            array.Add( o );
+                        }
+                    }
+
+                    break;
+                }
+                case "dress":
+                {
+                    foreach ( DressAgentEntry entry in DressManager.GetInstance().Items ?? Enumerable.Empty<DressAgentEntry>() )
+                    {
+                        JArray items = new JArray();
+
+                        foreach ( DressAgentItem item in entry.Items ?? new List<DressAgentItem>() )
+                        {
+                            items.Add( new JObject
+                            {
+                                ["name"] = item.Name,
+                                ["serial"] = item.Serial != 0 ? $"0x{item.Serial:x8}" : null,
+                                ["graphic"] = $"0x{item.ID:x4}",
+                                ["layer"] = item.Layer.ToString()
+                            } );
+                        }
+
+                        JObject o = new JObject
+                        {
+                            ["name"] = entry.Name,
+                            ["undressContainer"] = entry.UndressContainer != 0 ? $"0x{entry.UndressContainer:x8}" : null,
+                            ["itemCount"] = items.Count,
+                            ["items"] = items
+                        };
+
+                        if ( Match( o ) )
+                        {
+                            array.Add( o );
+                        }
+                    }
+
+                    break;
+                }
+                case "organizer":
+                {
+                    foreach ( OrganizerEntry entry in OrganizerManager.GetInstance().Items ?? Enumerable.Empty<OrganizerEntry>() )
+                    {
+                        JArray items = new JArray();
+
+                        IEnumerable<OrganizerItem> organizerItems = entry.Items ?? Enumerable.Empty<OrganizerItem>();
+
+                        foreach ( OrganizerItem item in organizerItems )
+                        {
+                            items.Add( new JObject
+                            {
+                                ["item"] = item.Item,
+                                ["id"] = $"0x{item.ID:x4}",
+                                ["hue"] = item.Hue,
+                                ["amount"] = item.Amount
+                            } );
+                        }
+
+                        JObject o = new JObject
+                        {
+                            ["name"] = entry.Name,
+                            ["sourceContainer"] = entry.SourceContainer != 0 ? $"0x{entry.SourceContainer:x8}" : null,
+                            ["destinationContainer"] = entry.DestinationContainer != 0 ? $"0x{entry.DestinationContainer:x8}" : null,
+                            ["stack"] = entry.Stack,
+                            ["returnExcess"] = entry.ReturnExcess,
+                            ["itemCount"] = items.Count,
+                            ["items"] = items
+                        };
+
+                        if ( Match( o ) )
+                        {
+                            array.Add( o );
+                        }
+                    }
+
+                    break;
+                }
+                case "scavenger":
+                {
+                    foreach ( ScavengerEntry entry in ScavengerManager.GetInstance().Items ?? Enumerable.Empty<ScavengerEntry>() )
+                    {
+                        JObject o = new JObject
+                        {
+                            ["name"] = entry.Name,
+                            ["enabled"] = entry.Enabled,
+                            ["graphic"] = $"0x{entry.Graphic:x4}",
+                            ["hue"] = entry.Hue
+                        };
+
+                        if ( Match( o ) )
+                        {
+                            array.Add( o );
+                        }
+                    }
+
+                    break;
+                }
+                case "trappouch":
+                {
+                    foreach ( TrapPouchEntry entry in TrapPouchManager.GetInstance().Items ?? Enumerable.Empty<TrapPouchEntry>() )
+                    {
+                        JObject o = new JObject
+                        {
+                            ["name"] = entry.Name,
+                            ["serial"] = $"0x{entry.Serial:x8}"
+                        };
+
+                        if ( Match( o ) )
+                        {
+                            array.Add( o );
+                        }
+                    }
+
+                    break;
+                }
+                case "vendorbuy":
+                {
+                    foreach ( VendorBuyAgentEntry entry in VendorBuyManager.GetInstance().Items ?? Enumerable.Empty<VendorBuyAgentEntry>() )
+                    {
+                        JArray items = new JArray();
+
+                        IEnumerable<VendorBuyAgentItem> buyItems = entry.Items ?? Enumerable.Empty<VendorBuyAgentItem>();
+
+                        foreach ( VendorBuyAgentItem item in buyItems )
+                        {
+                            items.Add( new JObject
+                            {
+                                ["name"] = item.Name,
+                                ["enabled"] = item.Enabled,
+                                ["graphic"] = $"0x{item.Graphic:x4}",
+                                ["hue"] = item.Hue,
+                                ["amount"] = item.Amount
+                            } );
+                        }
+
+                        JObject o = new JObject
+                        {
+                            ["name"] = entry.Name,
+                            ["enabled"] = entry.Enabled,
+                            ["itemCount"] = items.Count,
+                            ["items"] = items
+                        };
+
+                        if ( Match( o ) )
+                        {
+                            array.Add( o );
+                        }
+                    }
+
+                    break;
+                }
+                case "autoloot":
+                {
+                    foreach ( AutolootEntry entry in AutolootManager.GetInstance().GetEntries() ?? new List<AutolootEntry>() )
+                    {
+                        JObject o = new JObject
+                        {
+                            ["name"] = entry.Name,
+                            ["enabled"] = entry.Enabled,
+                            ["autoloot"] = entry.Autoloot,
+                            ["constraintCount"] = entry.Constraints?.Count ?? 0
+                        };
+
+                        if ( Match( o ) )
+                        {
+                            array.Add( o );
+                        }
+                    }
+
+                    break;
+                }
+            }
+
+            return array;
+        }
+
+        private static string Normalize( string agent )
+        {
+            if ( string.IsNullOrEmpty( agent ) )
+            {
+                return agent;
+            }
+
+            agent = agent.ToLowerInvariant().Trim().Replace( "-", "" ).Replace( "_", "" ).Replace( " ", "" );
+
+            switch ( agent )
+            {
+                case "vendorbuy":
+                case "venderbuy":
+                case "vendor_buy":
+                    return "vendorbuy";
+                case "trappouch":
+                case "trappouches":
+                case "trap_pouch":
+                    return "trappouch";
+                default:
+                    return agent;
+            }
+        }
+
+        private static T OnUi<T>( Func<T> func )
+        {
+            if ( Engine.Dispatcher == null )
+            {
+                return func();
+            }
+
+            return Engine.Dispatcher.Invoke( func );
+        }
+    }
+}

--- a/ClassicAssist/Mcp/McpCommandInvoker.cs
+++ b/ClassicAssist/Mcp/McpCommandInvoker.cs
@@ -1,0 +1,494 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using ClassicAssist.Data.Macros;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace ClassicAssist.Mcp
+{
+    public static class McpCommandInvoker
+    {
+        private static readonly Type[] _commandClasses = Assembly.GetExecutingAssembly().GetTypes()
+            .Where( t => t.Namespace != null && t.IsPublic && t.IsClass &&
+                         t.Namespace.EndsWith( "Macros.Commands" ) )
+            .ToArray();
+
+        public static IReadOnlyList<McpTool> GetTools()
+        {
+            return new List<McpTool>
+            {
+                new McpTool
+                {
+                    Name = "invokeCommand",
+                    Description = "Invoke any ClassicAssist macro command function directly by name (e.g. Pathfind, UseObject, Cast, FindType) without writing a macro. Arguments are passed as an object keyed by parameter name.",
+                    InputSchema = McpTools.ObjectSchema(
+                        new JObject
+                        {
+                            ["command"] = McpTools.StringProperty( "The macro command name (e.g. 'Pathfind')." ),
+                            ["arguments"] = new JObject
+                            {
+                                ["type"] = "object",
+                                ["description"] = "Arguments keyed by parameter name (e.g. {\"x\":990,\"y\":524,\"z\":-50})."
+                            }
+                        }, "command" )
+                },
+                new McpTool
+                {
+                    Name = "listCommands",
+                    Description = "List available ClassicAssist macro commands with their signatures.",
+                    InputSchema = McpTools.ObjectSchema(
+                        new JObject { ["filter"] = McpTools.StringProperty( "Optional case-insensitive substring to filter command names." ) } )
+                }
+            };
+        }
+
+        public static CallToolResult Invoke( string name, JObject args )
+        {
+            try
+            {
+                switch ( name )
+                {
+                    case "invokeCommand":
+                        return McpTools.Text( InvokeCommand(
+                            McpTools.RequireString( args, "command" ),
+                            args["arguments"] ) );
+                    case "listCommands":
+                        return McpTools.Text( ListCommands( McpTools.GetString( args, "filter" ) ) );
+                    default:
+                        return null;
+                }
+            }
+            catch ( Exception e )
+            {
+                return McpTools.Error( e.Message );
+            }
+        }
+
+        private static string InvokeCommand( string command, JToken args )
+        {
+            if ( string.IsNullOrWhiteSpace( command ) )
+            {
+                throw new InvalidOperationException( "Missing required argument 'command'." );
+            }
+
+            MethodInfo[] methods = _commandClasses
+                .SelectMany( t => t.GetMethods( BindingFlags.Public | BindingFlags.Static ) )
+                .Where( m => m.Name.Equals( command, StringComparison.OrdinalIgnoreCase ) )
+                .ToArray();
+
+            if ( methods.Length == 0 )
+            {
+                throw new InvalidOperationException(
+                    $"Command '{command}' not found. Use listCommands to see available commands." );
+            }
+
+            string[] errors = new string[methods.Length];
+
+            for ( int i = 0; i < methods.Length; i++ )
+            {
+                if ( TryBind( methods[i], args, out object[] parameters, out string bindError ) )
+                {
+                    object result = methods[i].Invoke( null, parameters );
+
+                    return FormatResult( methods[i], result );
+                }
+
+                errors[i] = bindError;
+            }
+
+            throw new InvalidOperationException(
+                $"Could not match arguments for command '{command}'. Expected signatures:\n{string.Join( "\n", errors )}" );
+        }
+
+        private static bool TryBind( MethodInfo method, JToken args, out object[] parameters, out string error )
+        {
+            ParameterInfo[] methodParams = method.GetParameters();
+            parameters = new object[methodParams.Length];
+
+            for ( int i = 0; i < methodParams.Length; i++ )
+            {
+                ParameterInfo parameter = methodParams[i];
+                JToken value = null;
+
+                if ( args is JObject named )
+                {
+                    value = named.Properties()
+                        .FirstOrDefault( x => x.Name.Equals( parameter.Name, StringComparison.OrdinalIgnoreCase ) )
+                        ?.Value;
+                }
+                else if ( args is JArray array && i < array.Count )
+                {
+                    value = array[i];
+                }
+
+                if ( value == null || value.Type == JTokenType.Null )
+                {
+                    if ( parameter.HasDefaultValue )
+                    {
+                        parameters[i] = parameter.DefaultValue;
+                        continue;
+                    }
+
+                    error = $"{method.Name}({DescribeParams( methodParams )}): missing required argument '{parameter.Name}'";
+                    return false;
+                }
+
+                if ( !TryConvert( value, parameter.ParameterType, out object converted, out string convertError ) )
+                {
+                    error = $"{method.Name}({DescribeParams( methodParams )}): {convertError}";
+                    return false;
+                }
+
+                parameters[i] = converted;
+            }
+
+            error = null;
+            return true;
+        }
+
+        private static bool TryConvert( JToken value, Type targetType, out object converted, out string error )
+        {
+            converted = null;
+            error = null;
+
+            Type underlying = Nullable.GetUnderlyingType( targetType ) ?? targetType;
+
+            if ( underlying == typeof( object ) )
+            {
+                // Serial/alias: pass numeric serials as int, otherwise as string (alias).
+                if ( value.Type == JTokenType.Integer )
+                {
+                    converted = value.ToObject<int>();
+                    return true;
+                }
+
+                string text = value.ToObject<string>();
+
+                if ( McpTools.TryParseInt( text, out int serial ) )
+                {
+                    converted = serial;
+                }
+                else
+                {
+                    converted = text;
+                }
+
+                return true;
+            }
+
+            if ( underlying == typeof( string ) )
+            {
+                if ( value.Type == JTokenType.String )
+                {
+                    converted = value.ToObject<string>();
+                }
+                else
+                {
+                    converted = value.ToString();
+                }
+
+                return true;
+            }
+
+            string raw = value.Type == JTokenType.String ? value.ToObject<string>() : value.ToString();
+
+            if ( underlying.IsEnum )
+            {
+                try
+                {
+                    object enumValue = Enum.Parse( underlying, raw, true );
+
+                    converted = enumValue;
+                    return true;
+                }
+                catch
+                {
+                    // try numeric below
+                }
+
+                if ( McpTools.TryParseInt( raw, out int enumNumber ) && Enum.IsDefined( underlying, enumNumber ) )
+                {
+                    converted = Enum.ToObject( underlying, enumNumber );
+                    return true;
+                }
+
+                error = $"'{raw}' is not a valid {underlying.Name}";
+                return false;
+            }
+
+            if ( underlying == typeof( bool ) )
+            {
+                switch ( raw.ToLowerInvariant() )
+                {
+                    case "true":
+                    case "1":
+                    case "on":
+                    case "yes":
+                        converted = true;
+                        return true;
+                    case "false":
+                    case "0":
+                    case "off":
+                    case "no":
+                        converted = false;
+                        return true;
+                    default:
+                        error = $"'{raw}' is not a valid boolean";
+                        return false;
+                }
+            }
+
+            if ( underlying == typeof( uint ) )
+            {
+                if ( raw.StartsWith( "0x", StringComparison.OrdinalIgnoreCase ) )
+                {
+                    if ( uint.TryParse( raw.Substring( 2 ), NumberStyles.HexNumber, CultureInfo.InvariantCulture,
+                             out uint uintValue ) )
+                    {
+                        converted = uintValue;
+                        return true;
+                    }
+                }
+                else if ( uint.TryParse( raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out uint uintValue ) )
+                {
+                    converted = uintValue;
+                    return true;
+                }
+
+                error = $"'{raw}' is not a valid UInt32";
+                return false;
+            }
+
+            if ( underlying == typeof( long ) )
+            {
+                if ( raw.StartsWith( "0x", StringComparison.OrdinalIgnoreCase ) )
+                {
+                    if ( long.TryParse( raw.Substring( 2 ), NumberStyles.HexNumber, CultureInfo.InvariantCulture,
+                             out long longValue ) )
+                    {
+                        converted = longValue;
+                        return true;
+                    }
+                }
+                else if ( long.TryParse( raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out long longValue ) )
+                {
+                    converted = longValue;
+                    return true;
+                }
+
+                error = $"'{raw}' is not a valid Int64";
+                return false;
+            }
+
+            if ( underlying == typeof( int ) || underlying == typeof( short ) ||
+                 underlying == typeof( byte ) || underlying == typeof( sbyte ) || underlying == typeof( ushort ) )
+            {
+                if ( McpTools.TryParseInt( raw, out int intValue ) )
+                {
+                    converted = Convert.ChangeType( intValue, underlying, CultureInfo.InvariantCulture );
+                    return true;
+                }
+
+                error = $"'{raw}' is not a valid {underlying.Name}";
+                return false;
+            }
+
+            if ( underlying == typeof( double ) || underlying == typeof( float ) || underlying == typeof( decimal ) )
+            {
+                try
+                {
+                    converted = Convert.ChangeType( value.ToObject<string>(), underlying, CultureInfo.InvariantCulture );
+                    return true;
+                }
+                catch
+                {
+                    error = $"'{raw}' is not a valid {underlying.Name}";
+                    return false;
+                }
+            }
+
+            if ( underlying == typeof( DateTime ) )
+            {
+                if ( DateTime.TryParse( value.ToObject<string>(), out DateTime date ) )
+                {
+                    converted = date;
+                    return true;
+                }
+
+                error = $"'{raw}' is not a valid DateTime";
+                return false;
+            }
+
+            // Fallback: try ChangeType.
+            try
+            {
+                converted = Convert.ChangeType( value.ToObject<string>(), underlying, CultureInfo.InvariantCulture );
+                return true;
+            }
+            catch
+            {
+                error = $"cannot convert '{raw}' to {underlying.Name}";
+                return false;
+            }
+        }
+
+        private static string FormatResult( MethodInfo method, object result )
+        {
+            if ( method.ReturnType == typeof( void ) )
+            {
+                return "OK";
+            }
+
+            if ( result == null )
+            {
+                return "null";
+            }
+
+            if ( method.ReturnType == typeof( bool ) )
+            {
+                return (bool) result ? "True" : "False";
+            }
+
+            return result.ToString();
+        }
+
+        private static string ListCommands( string filter )
+        {
+            JArray array = new JArray();
+
+            IEnumerable<MethodInfo> methods = _commandClasses
+                .SelectMany( t => t.GetMethods( BindingFlags.Public | BindingFlags.Static ) )
+                .Where( m => m.GetCustomAttributes<CommandsDisplayAttribute>().Any() );
+
+            if ( !string.IsNullOrEmpty( filter ) )
+            {
+                methods = methods.Where( m => m.Name.IndexOf( filter, StringComparison.OrdinalIgnoreCase ) >= 0 );
+            }
+
+            foreach ( MethodInfo method in methods.OrderBy( m => m.Name ) )
+            {
+                JObject entry = new JObject
+                {
+                    ["name"] = method.Name,
+                    ["signature"] = $"{method.Name}({DescribeParams( method.GetParameters() )})"
+                };
+
+                CommandsDisplayAttribute attr = method.GetCustomAttributes<CommandsDisplayAttribute>().FirstOrDefault();
+
+                if ( attr != null )
+                {
+                    if ( !string.IsNullOrEmpty( attr.Description ) )
+                    {
+                        entry["description"] = attr.Description;
+                    }
+
+                    if ( !string.IsNullOrEmpty( attr.Example ) )
+                    {
+                        entry["example"] = attr.Example;
+                    }
+
+                    ParameterInfo[] methodParams = method.GetParameters();
+
+                    if ( attr.Parameters != null && attr.Parameters.Length > 0 )
+                    {
+                        JArray paramArray = new JArray();
+
+                        for ( int i = 0; i < methodParams.Length; i++ )
+                        {
+                            string hint = i < attr.Parameters.Length ? GetParameterHint( attr.Parameters[i] ) : null;
+
+                            paramArray.Add( new JObject
+                            {
+                                ["name"] = methodParams[i].Name,
+                                ["hint"] = hint
+                            } );
+                        }
+
+                        entry["parameters"] = paramArray;
+                    }
+                }
+
+                array.Add( entry );
+            }
+
+            return JsonConvert.SerializeObject( array, Formatting.Indented );
+        }
+
+        private static string GetParameterHint( string parameterTypeName )
+        {
+            if ( !Enum.TryParse( parameterTypeName, out ParameterType type ) )
+            {
+                return parameterTypeName;
+            }
+
+            switch ( type )
+            {
+                case ParameterType.Serial:
+                    return "serial (0x hex or decimal)";
+                case ParameterType.SerialOrAlias:
+                    return "serial or alias (e.g. 0x400d379d or 'backpack')";
+                case ParameterType.ItemID:
+                    return "item/gump id";
+                case ParameterType.GumpButtonIndex:
+                    return "gump button id";
+                case ParameterType.Timeout:
+                    return "timeout in ms";
+                case ParameterType.Amount:
+                    return "amount (-1 for all)";
+                case ParameterType.AliasName:
+                    return "alias name";
+                case ParameterType.Range:
+                    return "range in tiles (-1 for any)";
+                case ParameterType.Distance:
+                    return "distance in tiles";
+                case ParameterType.Hue:
+                    return "hue";
+                case ParameterType.Direction:
+                    return "direction (e.g. 'East')";
+                case ParameterType.String:
+                    return "string";
+                case ParameterType.IntegerValue:
+                    return "integer";
+                case ParameterType.Boolean:
+                    return "bool";
+                case ParameterType.MacroName:
+                    return "macro name";
+                case ParameterType.SpellName:
+                    return "spell name (e.g. 'Recall')";
+                case ParameterType.SkillName:
+                    return "skill name";
+                case ParameterType.Layer:
+                    return "layer (e.g. 'Backpack')";
+                case ParameterType.ContextMenuIndex:
+                    return "context menu entry index";
+                case ParameterType.XCoordinate:
+                case ParameterType.XCoordinateOffset:
+                    return "x";
+                case ParameterType.YCoordinate:
+                case ParameterType.YCoordinateOffset:
+                    return "y";
+                case ParameterType.ZCoordinate:
+                case ParameterType.ZCoordinateOffset:
+                    return "z";
+                default:
+                    return type.ToString();
+            }
+        }
+
+        private static string DescribeParams( ParameterInfo[] parameters )
+        {
+            return string.Join( ", ", parameters.Select( p =>
+            {
+                string typeName = p.ParameterType == typeof( object )
+                    ? "serialOrAlias"
+                    : p.ParameterType.Name;
+                string optional = p.HasDefaultValue ? " = " + ( p.DefaultValue ?? "null" ) : "";
+
+                return $"{typeName} {p.Name}{optional}";
+            } ) );
+        }
+    }
+}

--- a/ClassicAssist/Mcp/McpGameStateTools.cs
+++ b/ClassicAssist/Mcp/McpGameStateTools.cs
@@ -1,0 +1,649 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Assistant;
+using ClassicAssist.Data;
+using ClassicAssist.UO;
+using ClassicAssist.UO.Data;
+using ClassicAssist.UO.Objects;
+using ClassicAssist.UO.Objects.Gumps;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace ClassicAssist.Mcp
+{
+    public static class McpGameStateTools
+    {
+        public static IReadOnlyList<McpTool> GetTools()
+        {
+            return new List<McpTool>
+            {
+                new McpTool
+                {
+                    Name = "getPlayer",
+                    Description = "Get the current player's properties (name, serial, hits, mana, stamina, stats, position, gold, weight, etc.).",
+                    InputSchema = McpTools.ObjectSchema()
+                },
+                new McpTool
+                {
+                    Name = "getBackpack",
+                    Description = "Get the contents of the player's backpack.",
+                    InputSchema = McpTools.ObjectSchema(
+                        new JObject
+                        {
+                            ["filter"] = McpTools.StringProperty( "Optional case-insensitive substring to filter item names." )
+                        } )
+                },
+                new McpTool
+                {
+                    Name = "getTileInfo",
+                    Description = "Get the land tile and statics at a map coordinate (like the Object Inspector).",
+                    InputSchema = McpTools.ObjectSchema(
+                        new JObject
+                        {
+                            ["x"] = McpTools.IntegerProperty( "The X coordinate." ),
+                            ["y"] = McpTools.IntegerProperty( "The Y coordinate." ),
+                            ["map"] = McpTools.IntegerProperty( "Optional map index (0-5), defaults to the player's map." )
+                        }, "x", "y" )
+                },
+                new McpTool
+                {
+                    Name = "listGumps",
+                    Description = "List all currently open gumps.",
+                    InputSchema = McpTools.ObjectSchema()
+                },
+                new McpTool
+                {
+                    Name = "getGumpLayout",
+                    Description = "Get the layout, strings and elements of a gump by id or serial.",
+                    InputSchema = McpTools.ObjectSchema(
+                        new JObject
+                        {
+                            ["id"] = McpTools.StringProperty( "Optional gump id (decimal or 0x hex)." ),
+                            ["serial"] = McpTools.StringProperty( "Optional gump serial (decimal or 0x hex)." )
+                        } )
+                },
+                new McpTool
+                {
+                    Name = "getItemInfo",
+                    Description = "Get detailed info and the list of cliloc properties for a mobile or item by serial.",
+                    InputSchema = McpTools.ObjectSchema(
+                        new JObject { ["serial"] = McpTools.StringProperty( "The entity serial (decimal or 0x hex)." ) }, "serial" )
+                },
+                new McpTool
+                {
+                    Name = "getCliloc",
+                    Description = "Get the localized string for a cliloc id (e.g. 1062724 = Sacred Journey).",
+                    InputSchema = McpTools.ObjectSchema(
+                        new JObject { ["cliloc"] = McpTools.IntegerProperty( "The cliloc id (decimal)." ) }, "cliloc" )
+                },
+                new McpTool
+                {
+                    Name = "getMobiles",
+                    Description = "Get the list of mobiles within a certain distance of the player.",
+                    InputSchema = McpTools.ObjectSchema(
+                        new JObject { ["range"] = McpTools.IntegerProperty( "Maximum distance in tiles from the player (default 10)." ) } )
+                },
+                new McpTool
+                {
+                    Name = "getItems",
+                    Description = "Get the list of items within a certain distance of the player.",
+                    InputSchema = McpTools.ObjectSchema(
+                        new JObject { ["range"] = McpTools.IntegerProperty( "Maximum distance in tiles from the player (default 10)." ) } )
+                },
+                new McpTool
+                {
+                    Name = "getContainer",
+                    Description = "Get the contents of a container (e.g. bank box or backpack) by serial.",
+                    InputSchema = McpTools.ObjectSchema(
+                        new JObject { ["serial"] = McpTools.StringProperty( "The container serial (decimal or 0x hex)." ) }, "serial" )
+                },
+                new McpTool
+                {
+                    Name = "getJournal",
+                    Description = "Get recent game journal entries (system messages, speech, macro output).",
+                    InputSchema = McpTools.ObjectSchema(
+                        new JObject
+                        {
+                            ["filter"] = McpTools.StringProperty( "Optional case-insensitive substring to filter entry text." ),
+                            ["count"] = McpTools.IntegerProperty( "Maximum number of most recent entries to return (default 20)." )
+                        } )
+                }
+            };
+        }
+
+        public static CallToolResult Invoke( string name, JObject args )
+        {
+            try
+            {
+                switch ( name )
+                {
+                    case "getPlayer":
+                        return McpTools.Text( GetPlayer() );
+                    case "getBackpack":
+                        return McpTools.Text( GetBackpack( McpTools.GetString( args, "filter" ) ) );
+                    case "getTileInfo":
+                        return McpTools.Text( GetTileInfo(
+                            McpTools.RequireInt( args, "x" ),
+                            McpTools.RequireInt( args, "y" ),
+                            McpTools.GetInt( args, "map" ) ) );
+                    case "listGumps":
+                        return McpTools.Text( ListGumps() );
+                    case "getGumpLayout":
+                        return McpTools.Text( GetGumpLayout(
+                            McpTools.GetString( args, "id" ),
+                            McpTools.GetString( args, "serial" ) ) );
+                    case "getItemInfo":
+                        return McpTools.Text( GetItemInfo( McpTools.RequireString( args, "serial" ) ) );
+                    case "getCliloc":
+                        return McpTools.Text( GetCliloc( McpTools.RequireInt( args, "cliloc" ) ) );
+                    case "getMobiles":
+                        return McpTools.Text( GetMobiles( McpTools.GetInt( args, "range" ) ?? 10 ) );
+                    case "getItems":
+                        return McpTools.Text( GetItems( McpTools.GetInt( args, "range" ) ?? 10 ) );
+                    case "getContainer":
+                        return McpTools.Text( GetContainer( McpTools.RequireString( args, "serial" ) ) );
+                    case "getJournal":
+                        return McpTools.Text( GetJournal( McpTools.GetString( args, "filter" ), McpTools.GetInt( args, "count" ) ) );
+                    default:
+                        return null;
+                }
+            }
+            catch ( Exception e )
+            {
+                return McpTools.Error( e.Message );
+            }
+        }
+
+        private static string GetPlayer()
+        {
+            PlayerMobile player = Engine.Player;
+
+            if ( player == null )
+            {
+                throw new InvalidOperationException( "Not connected - no player information available." );
+            }
+
+            JObject result = new JObject
+            {
+                ["name"] = player.Name,
+                ["serial"] = $"0x{player.Serial:x8}",
+                ["hits"] = player.Hits,
+                ["hitsMax"] = player.HitsMax,
+                ["mana"] = player.Mana,
+                ["manaMax"] = player.ManaMax,
+                ["stamina"] = player.Stamina,
+                ["staminaMax"] = player.StaminaMax,
+                ["strength"] = player.Strength,
+                ["dexterity"] = player.Dex,
+                ["intelligence"] = player.Int,
+                ["gold"] = player.Gold,
+                ["weight"] = player.Weight,
+                ["weightMax"] = player.WeightMax,
+                ["followers"] = player.Followers,
+                ["followersMax"] = player.FollowersMax,
+                ["tithingPoints"] = player.TithingPoints,
+                ["luck"] = player.Luck,
+                ["x"] = player.X,
+                ["y"] = player.Y,
+                ["z"] = player.Z,
+                ["map"] = player.Map.ToString(),
+                ["hue"] = player.Hue,
+                ["notoriety"] = player.Notoriety.ToString()
+            };
+
+            return JsonConvert.SerializeObject( result, Formatting.Indented );
+        }
+
+        private static string GetBackpack( string filter )
+        {
+            PlayerMobile player = Engine.Player;
+
+            if ( player == null )
+            {
+                throw new InvalidOperationException( "Not connected - no player information available." );
+            }
+
+            Item backpack = player.Backpack;
+
+            if ( backpack == null )
+            {
+                throw new InvalidOperationException( "Backpack not found." );
+            }
+
+            ItemCollection container = backpack.Container;
+
+            if ( container == null )
+            {
+                throw new InvalidOperationException( "Backpack is not open - no contents available." );
+            }
+
+            IEnumerable<Item> items = container.GetItems() ?? Array.Empty<Item>();
+
+            if ( !string.IsNullOrEmpty( filter ) )
+            {
+                items = items.Where( i => i.Name?.IndexOf( filter, StringComparison.OrdinalIgnoreCase ) >= 0 );
+            }
+
+            JArray array = new JArray();
+
+            foreach ( Item item in items )
+            {
+                array.Add( new JObject
+                {
+                    ["name"] = item.Name,
+                    ["serial"] = $"0x{item.Serial:x8}",
+                    ["graphic"] = $"0x{item.ID:x4}",
+                    ["hue"] = item.Hue,
+                    ["count"] = item.Count
+                } );
+            }
+
+            JObject result = new JObject
+            {
+                ["backpackSerial"] = $"0x{backpack.Serial:x8}",
+                ["itemCount"] = array.Count,
+                ["items"] = array
+            };
+
+            return JsonConvert.SerializeObject( result, Formatting.Indented );
+        }
+
+        private static string GetTileInfo( int x, int y, int? map )
+        {
+            int mapIndex = map ?? ( Engine.Player != null ? (int) Engine.Player.Map : 0 );
+
+            if ( mapIndex < 0 || mapIndex > 5 )
+            {
+                throw new InvalidOperationException( "Map must be between 0 and 5." );
+            }
+
+            LandTile landTile = MapInfo.GetLandTile( mapIndex, x, y );
+            StaticTile[] statics = Statics.GetStatics( mapIndex, x, y ) ?? Array.Empty<StaticTile>();
+
+            JObject land = new JObject
+            {
+                ["id"] = $"0x{landTile.ID:x4}",
+                ["name"] = landTile.Name,
+                ["z"] = landTile.Z,
+                ["flags"] = landTile.Flags.ToString()
+            };
+
+            JArray staticsArray = new JArray();
+
+            foreach ( StaticTile tile in statics )
+            {
+                staticsArray.Add( new JObject
+                {
+                    ["id"] = $"0x{tile.ID:x4}",
+                    ["name"] = tile.Name,
+                    ["z"] = tile.Z,
+                    ["hue"] = tile.Hue,
+                    ["flags"] = tile.Flags.ToString(),
+                    ["weight"] = tile.Weight,
+                    ["height"] = tile.Height
+                } );
+            }
+
+            JObject result = new JObject
+            {
+                ["x"] = x,
+                ["y"] = y,
+                ["map"] = ( (Map) mapIndex ).ToString(),
+                ["land"] = land,
+                ["statics"] = staticsArray
+            };
+
+            return JsonConvert.SerializeObject( result, Formatting.Indented );
+        }
+
+        private static string ListGumps()
+        {
+            JArray array = new JArray();
+
+            foreach ( Gump gump in GetGumps() )
+            {
+                array.Add( new JObject
+                {
+                    ["id"] = $"0x{gump.ID:x8}",
+                    ["serial"] = $"0x{gump.Serial:x8}",
+                    ["x"] = gump.X,
+                    ["y"] = gump.Y
+                } );
+            }
+
+            return JsonConvert.SerializeObject( array, Formatting.Indented );
+        }
+
+        private static string GetGumpLayout( string id, string serial )
+        {
+            Gump gump = null;
+
+            if ( !string.IsNullOrEmpty( id ) && McpTools.TryParseInt( id, out int idValue ) )
+            {
+                Engine.Gumps.GetGump( (uint) idValue, out gump );
+            }
+            else if ( !string.IsNullOrEmpty( serial ) && McpTools.TryParseInt( serial, out int serialValue ) )
+            {
+                Engine.Gumps.FindGump( serialValue, out gump );
+            }
+            else
+            {
+                Gump[] gumps = GetGumps();
+
+                if ( gumps.Length == 1 )
+                {
+                    gump = gumps[0];
+                }
+            }
+
+            if ( gump == null )
+            {
+                throw new InvalidOperationException( "Gump not found. Use listGumps to find an id or serial." );
+            }
+
+            JArray elements = new JArray();
+
+            GumpElement[] gumpElements;
+
+            try
+            {
+                gumpElements = gump.GumpElements ?? Array.Empty<GumpElement>();
+            }
+            catch
+            {
+                gumpElements = Array.Empty<GumpElement>();
+            }
+
+            foreach ( GumpElement element in gumpElements )
+            {
+                elements.Add( new JObject
+                {
+                    ["x"] = element.X,
+                    ["y"] = element.Y,
+                    ["type"] = element.Type.ToString(),
+                    ["cliloc"] = element.Cliloc,
+                    ["elementId"] = element.ElementID,
+                    ["text"] = element.Text
+                } );
+            }
+
+            JObject result = new JObject
+            {
+                ["id"] = $"0x{gump.ID:x8}",
+                ["serial"] = $"0x{gump.Serial:x8}",
+                ["x"] = gump.X,
+                ["y"] = gump.Y,
+                ["pageCount"] = gump.Pages?.Length ?? 0,
+                ["layout"] = gump.Layout ?? string.Empty,
+                ["strings"] = new JArray( gump.Strings ?? Array.Empty<string>() ),
+                ["elements"] = elements
+            };
+
+            return JsonConvert.SerializeObject( result, Formatting.Indented );
+        }
+
+        private static string GetCliloc( int cliloc )
+        {
+            string value = Cliloc.GetProperty( cliloc );
+
+            JObject result = new JObject
+            {
+                ["cliloc"] = cliloc,
+                ["text"] = value
+            };
+
+            return JsonConvert.SerializeObject( result, Formatting.Indented );
+        }
+
+        private static string GetItemInfo( string serialStr )
+        {
+            if ( !McpTools.TryParseInt( serialStr, out int serial ) )
+            {
+                throw new InvalidOperationException( $"Invalid serial: {serialStr}" );
+            }
+
+            Entity entity = FindEntity( serial );
+
+            if ( entity == null )
+            {
+                throw new InvalidOperationException( $"Entity 0x{serial:x8} not found." );
+            }
+
+            JObject result = new JObject
+            {
+                ["name"] = entity.Name,
+                ["serial"] = $"0x{entity.Serial:x8}",
+                ["graphic"] = $"0x{entity.ID:x4}",
+                ["hue"] = entity.Hue,
+                ["x"] = entity.X,
+                ["y"] = entity.Y,
+                ["z"] = entity.Z,
+                ["type"] = entity.GetType().Name
+            };
+
+            if ( entity is Mobile mobile )
+            {
+                result["hits"] = mobile.Hits;
+                result["hitsMax"] = mobile.HitsMax;
+                result["notoriety"] = mobile.Notoriety.ToString();
+            }
+            else if ( entity is Item item )
+            {
+                result["count"] = item.Count;
+
+                if ( item.Owner != 0 )
+                {
+                    result["owner"] = $"0x{item.Owner:x8}";
+                }
+
+                result["layer"] = item.Layer.ToString();
+            }
+
+            JArray properties = new JArray();
+
+            if ( entity.Properties != null )
+            {
+                foreach ( Property property in entity.Properties )
+                {
+                    properties.Add( new JObject
+                    {
+                        ["cliloc"] = property.Cliloc,
+                        ["text"] = property.Text,
+                        ["arguments"] = property.Arguments != null ? new JArray( property.Arguments ) : null
+                    } );
+                }
+            }
+
+            result["properties"] = properties;
+
+            return JsonConvert.SerializeObject( result, Formatting.Indented );
+        }
+
+        private static Entity FindEntity( int serial )
+        {
+            if ( UOMath.IsMobile( serial ) )
+            {
+                Mobile mobile = Engine.Mobiles.GetMobile( serial );
+
+                if ( mobile != null )
+                {
+                    return mobile;
+                }
+
+                return Engine.Player != null && Engine.Player.Serial == serial ? Engine.Player : null;
+            }
+
+            return Engine.Items.GetItem( serial );
+        }
+
+        private static string GetMobiles( int range )
+        {
+            if ( Engine.Player == null )
+            {
+                throw new InvalidOperationException( "Not connected - no player information available." );
+            }
+
+            IEnumerable<Mobile> mobiles = Engine.Mobiles.GetMobiles() ?? Array.Empty<Mobile>();
+
+            JArray array = new JArray();
+
+            foreach ( Mobile mobile in mobiles.Where( m => m.Distance <= range ) )
+            {
+                array.Add( new JObject
+                {
+                    ["name"] = mobile.Name,
+                    ["serial"] = $"0x{mobile.Serial:x8}",
+                    ["graphic"] = $"0x{mobile.ID:x4}",
+                    ["hue"] = mobile.Hue,
+                    ["x"] = mobile.X,
+                    ["y"] = mobile.Y,
+                    ["z"] = mobile.Z,
+                    ["distance"] = mobile.Distance,
+                    ["hits"] = mobile.Hits,
+                    ["hitsMax"] = mobile.HitsMax,
+                    ["notoriety"] = mobile.Notoriety.ToString()
+                } );
+            }
+
+            JObject result = new JObject
+            {
+                ["range"] = range,
+                ["mobileCount"] = array.Count,
+                ["mobiles"] = array
+            };
+
+            return JsonConvert.SerializeObject( result, Formatting.Indented );
+        }
+
+        private static string GetItems( int range )
+        {
+            if ( Engine.Player == null )
+            {
+                throw new InvalidOperationException( "Not connected - no player information available." );
+            }
+
+            IEnumerable<Item> items = Engine.Items.GetItems() ?? Array.Empty<Item>();
+
+            JArray array = new JArray();
+
+            foreach ( Item item in items.Where( i => i.Distance <= range ) )
+            {
+                array.Add( new JObject
+                {
+                    ["name"] = item.Name,
+                    ["serial"] = $"0x{item.Serial:x8}",
+                    ["graphic"] = $"0x{item.ID:x4}",
+                    ["hue"] = item.Hue,
+                    ["x"] = item.X,
+                    ["y"] = item.Y,
+                    ["z"] = item.Z,
+                    ["distance"] = item.Distance,
+                    ["count"] = item.Count,
+                    ["isContainer"] = item.IsContainer
+                } );
+            }
+
+            JObject result = new JObject
+            {
+                ["range"] = range,
+                ["itemCount"] = array.Count,
+                ["items"] = array
+            };
+
+            return JsonConvert.SerializeObject( result, Formatting.Indented );
+        }
+
+        private static string GetContainer( string serialStr )
+        {
+            if ( !McpTools.TryParseInt( serialStr, out int serial ) )
+            {
+                throw new InvalidOperationException( $"Invalid serial: {serialStr}" );
+            }
+
+            Item container = Engine.Items.GetItem( serial );
+
+            if ( container?.Container == null )
+            {
+                throw new InvalidOperationException( $"Entity 0x{serial:x8} is not an open container." );
+            }
+
+            JArray array = new JArray();
+
+            foreach ( Item item in container.Container.GetItems() )
+            {
+                array.Add( new JObject
+                {
+                    ["name"] = item.Name,
+                    ["serial"] = $"0x{item.Serial:x8}",
+                    ["graphic"] = $"0x{item.ID:x4}",
+                    ["hue"] = item.Hue,
+                    ["count"] = item.Count,
+                    ["x"] = item.X,
+                    ["y"] = item.Y
+                } );
+            }
+
+            JObject result = new JObject
+            {
+                ["containerSerial"] = $"0x{container.Serial:x8}",
+                ["itemCount"] = array.Count,
+                ["items"] = array
+            };
+
+            return JsonConvert.SerializeObject( result, Formatting.Indented );
+        }
+
+        private static string GetJournal( string filter, int? count )
+        {
+            JournalEntry[] buffer = Engine.Journal.GetEntireBuffer() ?? Array.Empty<JournalEntry>();
+
+            List<JournalEntry> entries = new List<JournalEntry>( buffer );
+
+            if ( !string.IsNullOrEmpty( filter ) )
+            {
+                entries = entries.Where( e => e.Text?.IndexOf( filter, StringComparison.OrdinalIgnoreCase ) >= 0 )
+                    .ToList();
+            }
+
+            int max = count ?? 20;
+
+            if ( entries.Count > max )
+            {
+                entries = entries.Skip( entries.Count - max ).ToList();
+            }
+
+            JArray array = new JArray();
+
+            foreach ( JournalEntry entry in entries )
+            {
+                array.Add( new JObject
+                {
+                    ["text"] = entry.Text,
+                    ["author"] = entry.Name,
+                    ["serial"] = entry.Serial != 0 ? $"0x{entry.Serial:x8}" : null,
+                    ["cliloc"] = entry.Cliloc,
+                    ["speechType"] = entry.SpeechType.ToString()
+                } );
+            }
+
+            JObject result = new JObject
+            {
+                ["entryCount"] = array.Count,
+                ["entries"] = array
+            };
+
+            return JsonConvert.SerializeObject( result, Formatting.Indented );
+        }
+
+        private static Gump[] GetGumps()
+        {
+            if ( Engine.Gumps.GetGumps( out Gump[] gumps ) )
+            {
+                return gumps;
+            }
+
+            return Array.Empty<Gump>();
+        }
+    }
+}

--- a/ClassicAssist/Mcp/McpServer.cs
+++ b/ClassicAssist/Mcp/McpServer.cs
@@ -1,0 +1,410 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace ClassicAssist.Mcp
+{
+    public static class McpServer
+    {
+        private const string PROTOCOL_VERSION = "2025-06-18";
+        private const string SERVER_VERSION = "1.0.0";
+
+        private static TcpListener _listener;
+        private static CancellationTokenSource _cts;
+
+        public static bool IsRunning => _listener != null;
+
+        public static int Port { get; private set; }
+
+        public static void Initialize( int port )
+        {
+            if ( _listener != null )
+            {
+                return;
+            }
+
+            Port = port;
+
+            _cts = new CancellationTokenSource();
+
+            try
+            {
+                // Bind to loopback only - the MCP port must never be exposed on the network.
+                _listener = new TcpListener( IPAddress.Loopback, port );
+                _listener.Start();
+            }
+            catch
+            {
+                _cts.Dispose();
+                _cts = null;
+                _listener = null;
+                throw;
+            }
+
+            CancellationToken token = _cts.Token;
+            Task.Run( () => AcceptLoop( token ) );
+        }
+
+        public static void Shutdown()
+        {
+            _cts?.Cancel();
+
+            try
+            {
+                _listener?.Stop();
+            }
+            catch
+            {
+                // ignored
+            }
+
+            _listener = null;
+            _cts = null;
+        }
+
+        private static async Task AcceptLoop( CancellationToken token )
+        {
+            while ( !token.IsCancellationRequested && _listener != null )
+            {
+                TcpClient client;
+
+                try
+                {
+                    client = await _listener.AcceptTcpClientAsync();
+                }
+                catch ( ObjectDisposedException )
+                {
+                    break;
+                }
+                catch ( SocketException )
+                {
+                    break;
+                }
+                catch ( Exception )
+                {
+                    if ( token.IsCancellationRequested )
+                    {
+                        break;
+                    }
+
+                    continue;
+                }
+
+                _ = Task.Run( () => HandleClient( client, token ) );
+            }
+        }
+
+        private static async Task HandleClient( TcpClient client, CancellationToken token )
+        {
+            using ( client )
+            {
+                using ( CancellationTokenSource timeoutCts = CancellationTokenSource.CreateLinkedTokenSource( token ) )
+                {
+                    timeoutCts.CancelAfter( TimeSpan.FromSeconds( 30 ) );
+
+                    try
+                    {
+                        using ( NetworkStream stream = client.GetStream() )
+                        {
+                            byte[] request = await ReadHttpRequestAsync( stream, timeoutCts.Token );
+
+                            if ( request == null )
+                            {
+                                return;
+                            }
+
+                            byte[] response = Process( request );
+
+                            if ( response != null )
+                            {
+                                await stream.WriteAsync( response, 0, response.Length, timeoutCts.Token );
+                                await stream.FlushAsync( timeoutCts.Token );
+                            }
+                        }
+                    }
+                    catch
+                    {
+                        // ignored - client disconnected or timed out
+                    }
+                }
+            }
+        }
+
+        private static async Task<byte[]> ReadHttpRequestAsync( NetworkStream stream, CancellationToken token )
+        {
+            byte[] buffer = new byte[8192];
+            MemoryStream pending = new MemoryStream();
+            int headerEnd = -1;
+            int contentLength = 0;
+
+            while ( true )
+            {
+                int read = await stream.ReadAsync( buffer, 0, buffer.Length, token );
+
+                if ( read == 0 )
+                {
+                    return null;
+                }
+
+                pending.Write( buffer, 0, read );
+
+                byte[] data = pending.GetBuffer();
+                int length = (int) pending.Length;
+
+                if ( headerEnd < 0 )
+                {
+                    headerEnd = IndexOfHeaderTerminator( data, length );
+
+                    if ( headerEnd >= 0 )
+                    {
+                        contentLength = ParseContentLength( data, headerEnd );
+                    }
+                    else if ( length > 64 * 1024 )
+                    {
+                        return null;
+                    }
+                }
+
+                if ( headerEnd >= 0 && length >= headerEnd + 4 + contentLength )
+                {
+                    byte[] result = new byte[headerEnd + 4 + contentLength];
+                    Buffer.BlockCopy( data, 0, result, 0, result.Length );
+                    return result;
+                }
+            }
+        }
+
+        private static byte[] Process( byte[] request )
+        {
+            int headerEnd = IndexOfHeaderTerminator( request, request.Length );
+
+            if ( headerEnd < 0 )
+            {
+                return HttpResponse( 400, "Bad Request", Array.Empty<byte>() );
+            }
+
+            string headerText = Encoding.ASCII.GetString( request, 0, headerEnd );
+            string[] lines = headerText.Split( new[] { "\r\n" }, StringSplitOptions.None );
+            string requestLine = lines.Length > 0 ? lines[0] : string.Empty;
+            string[] requestParts = requestLine.Split( new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries );
+
+            string method = requestParts.Length > 0 ? requestParts[0] : string.Empty;
+            string path = requestParts.Length > 1 ? requestParts[1] : "/";
+
+            if ( method.Equals( "OPTIONS", StringComparison.OrdinalIgnoreCase ) )
+            {
+                return HttpResponse( 204, "No Content", Array.Empty<byte>() );
+            }
+
+            if ( !method.Equals( "POST", StringComparison.OrdinalIgnoreCase ) )
+            {
+                return HttpResponse( 405, "Method Not Allowed", Array.Empty<byte>(), "Allow: POST, OPTIONS\r\n" );
+            }
+
+            if ( !path.Equals( "/", StringComparison.OrdinalIgnoreCase ) &&
+                 !path.Equals( "/mcp", StringComparison.OrdinalIgnoreCase ) )
+            {
+                return HttpResponse( 404, "Not Found", Array.Empty<byte>() );
+            }
+
+            int bodyStart = headerEnd + 4;
+            int bodyLength = request.Length - bodyStart;
+
+            if ( bodyLength <= 0 )
+            {
+                return RpcError( null, -32600, "Invalid Request: empty body" );
+            }
+
+            string body = Encoding.UTF8.GetString( request, bodyStart, bodyLength );
+
+            JsonRpcRequest rpcRequest;
+
+            try
+            {
+                rpcRequest = JsonConvert.DeserializeObject<JsonRpcRequest>( body );
+            }
+            catch
+            {
+                return RpcError( null, -32700, "Parse error" );
+            }
+
+            if ( rpcRequest == null || string.IsNullOrEmpty( rpcRequest.Method ) )
+            {
+                return RpcError( null, -32600, "Invalid Request" );
+            }
+
+            JsonRpcResponse response = Handle( rpcRequest );
+
+            if ( response == null )
+            {
+                // Notification (or unknown notification) - no JSON-RPC response, but the HTTP
+                // layer must still answer so the client doesn't see the connection drop.
+                return HttpResponse( 202, "Accepted", Array.Empty<byte>() );
+            }
+
+            byte[] responseBody = Encoding.UTF8.GetBytes( JsonConvert.SerializeObject( response ) );
+
+            return HttpResponse( 200, "OK", responseBody );
+        }
+
+        private static JsonRpcResponse Handle( JsonRpcRequest request )
+        {
+            switch ( request.Method )
+            {
+                case "initialize":
+                    return Result( request, Initialize() );
+                case "ping":
+                    return Result( request, new JObject() );
+                case "tools/list":
+                    return Result( request, new JObject { ["tools"] = JToken.FromObject( McpTools.GetTools() ) } );
+                case "tools/call":
+                    return HandleToolsCall( request );
+                case "notifications/initialized":
+                case "notifications/cancelled":
+                    return null;
+                default:
+                    // Unknown notification - no response. Unknown request - method not found.
+                    return request.Id == null ? null : Error( request, -32601, "Method not found" );
+            }
+        }
+
+        private static JsonRpcResponse HandleToolsCall( JsonRpcRequest request )
+        {
+            CallToolParams callParams;
+
+            try
+            {
+                callParams = request.Params?.ToObject<CallToolParams>();
+            }
+            catch
+            {
+                return Error( request, -32602, "Invalid params" );
+            }
+
+            if ( callParams == null || string.IsNullOrEmpty( callParams.Name ) )
+            {
+                return Error( request, -32602, "Invalid params: missing tool name" );
+            }
+
+            try
+            {
+                CallToolResult result = McpTools.Invoke( callParams.Name, callParams.Arguments );
+
+                return Result( request, result );
+            }
+            catch ( Exception e )
+            {
+                return Result( request, new CallToolResult
+                {
+                    IsError = true,
+                    Content = new List<McpContent> { new McpContent { Text = e.Message } }
+                } );
+            }
+        }
+
+        private static JObject Initialize()
+        {
+            return new JObject
+            {
+                ["protocolVersion"] = PROTOCOL_VERSION,
+                ["capabilities"] = new JObject { ["tools"] = new JObject() },
+                ["serverInfo"] = new JObject { ["name"] = "ClassicAssist", ["version"] = SERVER_VERSION },
+                ["instructions"] = "Tools for inspecting, creating, editing and running ClassicAssist macros."
+            };
+        }
+
+        private static JsonRpcResponse Result( JsonRpcRequest request, object result )
+        {
+            return new JsonRpcResponse { Id = request.Id, Result = result };
+        }
+
+        private static byte[] RpcError( object id, int code, string message )
+        {
+            JsonRpcResponse response = new JsonRpcResponse
+            {
+                Id = id,
+                Error = new JsonRpcError { Code = code, Message = message }
+            };
+
+            return HttpResponse( 200, "OK", Encoding.UTF8.GetBytes( JsonConvert.SerializeObject( response ) ) );
+        }
+
+        private static JsonRpcResponse Error( JsonRpcRequest request, int code, string message )
+        {
+            return new JsonRpcResponse
+            {
+                Id = request.Id,
+                Error = new JsonRpcError { Code = code, Message = message }
+            };
+        }
+
+        private static byte[] HttpResponse( int statusCode, string statusText, byte[] body, string extraHeaders = null )
+        {
+            StringBuilder header = new StringBuilder();
+
+            header.Append( $"HTTP/1.1 {statusCode} {statusText}\r\n" );
+            header.Append( "Content-Type: application/json\r\n" );
+            header.Append( $"MCP-Protocol-Version: {PROTOCOL_VERSION}\r\n" );
+            header.Append( "Access-Control-Allow-Origin: *\r\n" );
+            header.Append( "Access-Control-Allow-Methods: POST, OPTIONS\r\n" );
+            header.Append( "Access-Control-Allow-Headers: content-type, mcp-protocol-version, mcp-session-id, accept\r\n" );
+
+            if ( extraHeaders != null )
+            {
+                header.Append( extraHeaders );
+            }
+
+            header.Append( $"Content-Length: {body.Length}\r\n" );
+            header.Append( "Connection: close\r\n" );
+            header.Append( "\r\n" );
+
+            byte[] headerBytes = Encoding.ASCII.GetBytes( header.ToString() );
+            byte[] result = new byte[headerBytes.Length + body.Length];
+            headerBytes.CopyTo( result, 0 );
+            body.CopyTo( result, headerBytes.Length );
+
+            return result;
+        }
+
+        private static int IndexOfHeaderTerminator( byte[] data, int length )
+        {
+            for ( int i = 0; i + 3 < length; i++ )
+            {
+                if ( data[i] == (byte) '\r' && data[i + 1] == (byte) '\n' &&
+                     data[i + 2] == (byte) '\r' && data[i + 3] == (byte) '\n' )
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        private static int ParseContentLength( byte[] data, int headerEnd )
+        {
+            string header = Encoding.ASCII.GetString( data, 0, headerEnd );
+
+            foreach ( string line in header.Split( new[] { "\r\n" }, StringSplitOptions.None ) )
+            {
+                if ( line.StartsWith( "Content-Length:", StringComparison.OrdinalIgnoreCase ) )
+                {
+                    int contentLength;
+
+                    if ( int.TryParse( line.Substring( 15 ).Trim(), out contentLength ) )
+                    {
+                        return contentLength;
+                    }
+                }
+            }
+
+            return 0;
+        }
+    }
+}

--- a/ClassicAssist/Mcp/McpTools.cs
+++ b/ClassicAssist/Mcp/McpTools.cs
@@ -1,0 +1,701 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Assistant;
+using ClassicAssist.Data;
+using ClassicAssist.Data.Macros;
+using ClassicAssist.Data.Macros.Commands;
+using IronPython.Runtime.Operations;
+using Microsoft.Scripting;
+using Microsoft.Scripting.Runtime;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace ClassicAssist.Mcp
+{
+    public static class McpTools
+    {
+        public static IReadOnlyList<McpTool> GetTools()
+        {
+            List<McpTool> tools = new List<McpTool>
+            {
+                new McpTool
+                {
+                    Name = "listMacros",
+                    Description = "List all macros with their current status and metadata.",
+                    InputSchema = ObjectSchema(
+                        new JObject
+                        {
+                            ["filter"] = StringProperty( "Optional case-insensitive substring to filter macro names." )
+                        } )
+                },
+                new McpTool
+                {
+                    Name = "getMacro",
+                    Description = "Get the source code and metadata of a single macro by name.",
+                    InputSchema = ObjectSchema( new JObject { ["name"] = StringProperty( "The macro name." ) }, "name" )
+                },
+                new McpTool
+                {
+                    Name = "createMacro",
+                    Description = "Create a new macro with Python source code. Pass a filePath to store it as a file-backed .py macro; otherwise it is embedded in the profile.",
+                    InputSchema = ObjectSchema(
+                        new JObject
+                        {
+                            ["name"] = StringProperty( "The macro name (must be unique)." ),
+                            ["code"] = StringProperty( "The Python macro source code." ),
+                            ["background"] = new JObject { ["type"] = "boolean", ["description"] = "Whether the macro runs in the background (optional)." },
+                            ["filePath"] = StringProperty( "Optional file path (absolute or relative to the Macros folder) to write the macro to a .py file." )
+                        }, "name", "code" )
+                },
+                new McpTool
+                {
+                    Name = "updateMacro",
+                    Description = "Update an existing macro's source code and/or rename it.",
+                    InputSchema = ObjectSchema(
+                        new JObject
+                        {
+                            ["name"] = StringProperty( "The macro name to update." ),
+                            ["code"] = StringProperty( "New Python source code (optional)." ),
+                            ["newName"] = StringProperty( "New name for the macro (optional)." )
+                        }, "name" )
+                },
+                new McpTool
+                {
+                    Name = "deleteMacro",
+                    Description = "Delete a macro by name.",
+                    InputSchema = ObjectSchema( new JObject { ["name"] = StringProperty( "The macro name." ) }, "name" )
+                },
+                new McpTool
+                {
+                    Name = "playMacro",
+                    Description = "Run a macro by name, optionally passing string arguments. Waits up to waitMs (default 3000) for the macro to finish or error, then reports the result including any error.",
+                    InputSchema = ObjectSchema(
+                        new JObject
+                        {
+                            ["name"] = StringProperty( "The macro name to run." ),
+                            ["args"] = new JObject
+                            {
+                                ["type"] = "array",
+                                ["items"] = new JObject { ["type"] = "string" },
+                                ["description"] = "Optional arguments passed to the macro."
+                            },
+                            ["waitMs"] = IntegerProperty( "Optional maximum milliseconds to wait for the macro to finish or error (default 3000)." )
+                        }, "name" )
+                },
+                new McpTool
+                {
+                    Name = "stopMacro",
+                    Description = "Stop a running macro by name, or the currently running macro if no name is given.",
+                    InputSchema = ObjectSchema( new JObject { ["name"] = StringProperty( "The macro name (optional)." ) } )
+                },
+                new McpTool
+                {
+                    Name = "stopAllMacros",
+                    Description = "Stop all running macros.",
+                    InputSchema = ObjectSchema()
+                },
+                new McpTool
+                {
+                    Name = "getMacroStatus",
+                    Description = "Get the running, paused and error status of a macro by name, or of all macros if no name is given.",
+                    InputSchema = ObjectSchema( new JObject { ["name"] = StringProperty( "The macro name (optional)." ) } )
+                }
+            };
+
+            tools.AddRange( McpGameStateTools.GetTools() );
+            tools.AddRange( McpCommandInvoker.GetTools() );
+            tools.AddRange( McpAgentTools.GetTools() );
+
+            return tools;
+        }
+
+        public static CallToolResult Invoke( string name, JObject args )
+        {
+            try
+            {
+                switch ( name )
+                {
+                    case "listMacros":
+                        return Text( ListMacros( GetString( args, "filter" ) ) );
+                    case "getMacro":
+                        return Text( GetMacro( RequireString( args, "name" ) ) );
+                    case "createMacro":
+                        return Text( CreateMacro(
+                            RequireString( args, "name" ),
+                            RequireString( args, "code" ),
+                            GetBool( args, "background" ),
+                            GetString( args, "filePath" ) ) );
+                    case "updateMacro":
+                        return Text( UpdateMacro(
+                            RequireString( args, "name" ),
+                            GetString( args, "code" ),
+                            GetString( args, "newName" ) ) );
+                    case "deleteMacro":
+                        return Text( DeleteMacro( RequireString( args, "name" ) ) );
+                    case "playMacro":
+                        return Text( PlayMacro( RequireString( args, "name" ), GetStringArray( args, "args" ), GetInt( args, "waitMs" ) ) );
+                    case "stopMacro":
+                        return Text( StopMacro( GetString( args, "name" ) ) );
+                    case "stopAllMacros":
+                        return Text( StopAllMacros() );
+                    case "getMacroStatus":
+                        return Text( GetMacroStatus( GetString( args, "name" ) ) );
+                    default:
+                    {
+                        CallToolResult result = McpGameStateTools.Invoke( name, args ) ??
+                                               McpCommandInvoker.Invoke( name, args ) ??
+                                               McpAgentTools.Invoke( name, args );
+
+                        return result ?? Error( $"Unknown tool: {name}" );
+                    }
+                }
+            }
+            catch ( Exception e )
+            {
+                return Error( e.Message );
+            }
+        }
+
+        private static string ListMacros( string filter )
+        {
+            List<JObject> results = OnUi( () =>
+            {
+                IEnumerable<MacroEntry> items = GetItems();
+
+                if ( !string.IsNullOrEmpty( filter ) )
+                {
+                    items = items.Where( m => m.Name.IndexOf( filter, StringComparison.OrdinalIgnoreCase ) >= 0 );
+                }
+
+                return items.OrderBy( m => m.Name ).Select( Summarize ).ToList();
+            } );
+
+            return JsonConvert.SerializeObject( results, Formatting.Indented );
+        }
+
+        private static string GetMacro( string name )
+        {
+            JObject result = OnUi( () =>
+            {
+                MacroEntry entry = Find( name );
+
+                if ( entry == null )
+                {
+                    return null;
+                }
+
+                return new JObject
+                {
+                    ["name"] = entry.Name,
+                    ["code"] = entry.Macro ?? string.Empty,
+                    ["isFileBacked"] = entry.IsFileBacked,
+                    ["filePath"] = entry.FilePath,
+                    ["isBackground"] = entry.IsBackground,
+                    ["loop"] = entry.Loop,
+                    ["group"] = entry.Group ?? string.Empty
+                };
+            } );
+
+            return result == null
+                ? throw new InvalidOperationException( $"Macro '{name}' not found." )
+                : JsonConvert.SerializeObject( result, Formatting.Indented );
+        }
+
+        private static string CreateMacro( string name, string code, bool background, string filePath )
+        {
+            return OnUi( () =>
+            {
+                MacroManager manager = MacroManager.GetInstance();
+
+                EnsureItems( manager );
+
+                if ( manager.Items.Any( m => m.Name.Equals( name, StringComparison.OrdinalIgnoreCase ) ) )
+                {
+                    throw new InvalidOperationException( $"Macro '{name}' already exists." );
+                }
+
+                MacroEntry entry = new MacroEntry { Name = name, Macro = code ?? string.Empty, IsBackground = background };
+
+                if ( !string.IsNullOrEmpty( filePath ) )
+                {
+                    string resolved = ResolveMacrosPath( filePath );
+
+                    string dir = Path.GetDirectoryName( resolved );
+
+                    if ( !string.IsNullOrEmpty( dir ) )
+                    {
+                        Directory.CreateDirectory( dir );
+                    }
+
+                    File.WriteAllText( resolved, entry.Macro );
+                    entry.FilePath = resolved;
+                }
+
+                entry.Action = ( hks, parameters ) => MacroManager.GetInstance().Execute( entry, parameters );
+
+                manager.Items.Add( entry );
+
+                Options.Save( Options.CurrentOptions );
+
+                JObject summary = Summarize( entry );
+                summary["code"] = entry.Macro;
+
+                return JsonConvert.SerializeObject( summary, Formatting.Indented );
+            } );
+        }
+
+        private static string UpdateMacro( string name, string code, string newName )
+        {
+            return OnUi( () =>
+            {
+                MacroEntry entry = Find( name );
+
+                if ( entry == null )
+                {
+                    throw new InvalidOperationException( $"Macro '{name}' not found." );
+                }
+
+                if ( code != null )
+                {
+                    entry.Macro = code;
+                }
+
+                if ( !string.IsNullOrEmpty( newName ) && !newName.Equals( entry.Name, StringComparison.Ordinal ) )
+                {
+                    MacroManager manager = MacroManager.GetInstance();
+
+                    if ( manager.Items.Any( m => !ReferenceEquals( m, entry ) &&
+                                                 m.Name.Equals( newName, StringComparison.OrdinalIgnoreCase ) ) )
+                    {
+                        throw new InvalidOperationException( $"Macro '{newName}' already exists." );
+                    }
+
+                    entry.Name = newName;
+                }
+
+                Options.Save( Options.CurrentOptions );
+
+                JObject summary = Summarize( entry );
+                summary["code"] = entry.Macro;
+
+                return JsonConvert.SerializeObject( summary, Formatting.Indented );
+            } );
+        }
+
+        private static string DeleteMacro( string name )
+        {
+            return OnUi( () =>
+            {
+                MacroEntry entry = Find( name );
+
+                if ( entry == null )
+                {
+                    throw new InvalidOperationException( $"Macro '{name}' not found." );
+                }
+
+                string filePath = entry.IsFileBacked ? entry.FilePath : null;
+
+                if ( entry.IsRunning )
+                {
+                    entry.Stop();
+                }
+
+                MacroManager.GetInstance().Items.Remove( entry );
+
+                if ( !string.IsNullOrEmpty( filePath ) )
+                {
+                    try
+                    {
+                        File.Delete( filePath );
+                    }
+                    catch
+                    {
+                        // best effort
+                    }
+                }
+
+                Options.Save( Options.CurrentOptions );
+
+                return $"Deleted macro '{name}'.";
+            } );
+        }
+
+        private const int DEFAULT_PLAY_WAIT_MS = 3000;
+
+        private static string PlayMacro( string name, string[] args, int? waitMs )
+        {
+            MacroEntry entry = OnUi( () => Find( name ) );
+
+            if ( entry == null )
+            {
+                throw new InvalidOperationException( $"Macro '{name}' not found." );
+            }
+
+            object[] parameters = args?.Cast<object>().ToArray();
+
+            MainCommands.BringClientWindowToFront();
+
+            MacroManager.GetInstance().Execute( entry, parameters );
+
+            JObject result = WaitForResult( entry, waitMs ?? DEFAULT_PLAY_WAIT_MS );
+
+            return JsonConvert.SerializeObject( result, Formatting.Indented );
+        }
+
+        private static JObject WaitForResult( MacroEntry entry, int timeoutMs )
+        {
+            const int pollInterval = 50;
+            int waited = 0;
+
+            while ( waited < timeoutMs )
+            {
+                if ( entry.LastException != null || !entry.IsRunning )
+                {
+                    break;
+                }
+
+                Thread.Sleep( pollInterval );
+                waited += pollInterval;
+            }
+
+            // Authoritative read on the UI thread - IsRunning and LastException are updated there.
+            (bool running, Exception exception) state = OnUi( () => ( entry.IsRunning, entry.LastException ) );
+
+            return new JObject
+            {
+                ["name"] = entry.Name,
+                ["isRunning"] = state.running,
+                ["success"] = !state.running && state.exception == null,
+                ["error"] = state.exception != null ? GetErrorInfo( state.exception ) : null
+            };
+        }
+
+        private static JObject GetErrorInfo( Exception exception )
+        {
+            JObject error = new JObject
+            {
+                ["type"] = exception.GetType().Name,
+                ["message"] = exception.Message
+            };
+
+            try
+            {
+                if ( exception is SyntaxErrorException syntaxError )
+                {
+                    error["line"] = syntaxError.RawSpan.Start.Line;
+                }
+                else
+                {
+                    DynamicStackFrame frame = PythonOps.GetDynamicStackFrames( exception ).FirstOrDefault();
+
+                    if ( frame != null )
+                    {
+                        string fileName = frame.GetFileName();
+
+                        if ( fileName != "<string>" )
+                        {
+                            error["file"] = fileName;
+                        }
+
+                        error["line"] = frame.GetFileLineNumber();
+                    }
+                }
+            }
+            catch
+            {
+                // best effort - message alone is still useful
+            }
+
+            return error;
+        }
+
+        private static string StopMacro( string name )
+        {
+            OnUi( () =>
+            {
+                MacroManager manager = MacroManager.GetInstance();
+
+                if ( string.IsNullOrEmpty( name ) )
+                {
+                    manager.Stop();
+                    return;
+                }
+
+                MacroEntry entry = Find( name );
+
+                if ( entry == null )
+                {
+                    throw new InvalidOperationException( $"Macro '{name}' not found." );
+                }
+
+                entry.Stop();
+            } );
+
+            return string.IsNullOrEmpty( name ) ? "Stopped current macro." : $"Stopped macro '{name}'.";
+        }
+
+        private static string StopAllMacros()
+        {
+            OnUi( () => MacroManager.GetInstance().StopAll() );
+
+            return "Stopped all macros.";
+        }
+
+        private static string GetMacroStatus( string name )
+        {
+            List<JObject> results = OnUi( () =>
+            {
+                IEnumerable<MacroEntry> items = GetItems();
+
+                if ( !string.IsNullOrEmpty( name ) )
+                {
+                    MacroEntry single = Find( name );
+
+                    if ( single == null )
+                    {
+                        throw new InvalidOperationException( $"Macro '{name}' not found." );
+                    }
+
+                    items = new[] { single };
+                }
+
+                return items.OrderBy( m => m.Name ).Select( StatusOf ).ToList();
+            } );
+
+            return JsonConvert.SerializeObject( results, Formatting.Indented );
+        }
+
+        private static JObject StatusOf( MacroEntry entry )
+        {
+            return new JObject
+            {
+                ["name"] = entry.Name,
+                ["isRunning"] = entry.IsRunning,
+                ["isPaused"] = entry.IsPaused,
+                ["pausedLine"] = entry.PausedLinedNumber,
+                ["lastException"] = entry.LastException?.Message,
+                ["error"] = entry.LastException != null ? GetErrorInfo( entry.LastException ) : null
+            };
+        }
+
+        private static JObject Summarize( MacroEntry entry )
+        {
+            return new JObject
+            {
+                ["name"] = entry.Name,
+                ["id"] = entry.Id,
+                ["isRunning"] = entry.IsRunning,
+                ["isPaused"] = entry.IsPaused,
+                ["isBackground"] = entry.IsBackground,
+                ["isFileBacked"] = entry.IsFileBacked,
+                ["filePath"] = entry.FilePath,
+                ["group"] = entry.Group ?? string.Empty,
+                ["loop"] = entry.Loop,
+                ["isAutostart"] = entry.IsAutostart
+            };
+        }
+
+        private static MacroEntry Find( string name )
+        {
+            return GetItems().FirstOrDefault( m => m.Name.Equals( name, StringComparison.OrdinalIgnoreCase ) );
+        }
+
+        private static IEnumerable<MacroEntry> GetItems()
+        {
+            ObservableCollection<MacroEntry> items = MacroManager.GetInstance().Items;
+
+            return items ?? Enumerable.Empty<MacroEntry>();
+        }
+
+        private static void EnsureItems( MacroManager manager )
+        {
+            if ( manager.Items == null )
+            {
+                throw new InvalidOperationException( "Macro collection is not initialized (Macros tab has not loaded)." );
+            }
+        }
+
+        private static string ResolveMacrosPath( string filePath )
+        {
+            if ( Path.IsPathRooted( filePath ) )
+            {
+                return filePath;
+            }
+
+            string resolved = Path.Combine( AssistantOptions.GetGlobalPath(), "Macros", filePath );
+
+            if ( !resolved.EndsWith( ".py", StringComparison.OrdinalIgnoreCase ) )
+            {
+                resolved += ".py";
+            }
+
+            return resolved;
+        }
+
+        private static T OnUi<T>( Func<T> func )
+        {
+            if ( Engine.Dispatcher == null )
+            {
+                return func();
+            }
+
+            return Engine.Dispatcher.Invoke( func );
+        }
+
+        private static void OnUi( Action action )
+        {
+            if ( Engine.Dispatcher == null )
+            {
+                action();
+                return;
+            }
+
+            Engine.Dispatcher.Invoke( action );
+        }
+
+        internal static CallToolResult Text( string text )
+        {
+            return new CallToolResult { Content = new List<McpContent> { new McpContent { Text = text } } };
+        }
+
+        internal static CallToolResult Error( string message )
+        {
+            return new CallToolResult
+            {
+                IsError = true,
+                Content = new List<McpContent> { new McpContent { Text = message } }
+            };
+        }
+
+        internal static JObject ObjectSchema( JObject properties = null, params string[] required )
+        {
+            JObject schema = new JObject { ["type"] = "object" };
+
+            if ( properties != null && properties.Count > 0 )
+            {
+                schema["properties"] = properties;
+            }
+
+            if ( required != null && required.Length > 0 )
+            {
+                schema["required"] = new JArray( required );
+            }
+
+            return schema;
+        }
+
+        internal static JObject StringProperty( string description )
+        {
+            return new JObject { ["type"] = "string", ["description"] = description };
+        }
+
+        internal static JObject IntegerProperty( string description )
+        {
+            return new JObject { ["type"] = "integer", ["description"] = description };
+        }
+
+        internal static string RequireString( JObject args, string name )
+        {
+            string value = GetString( args, name );
+
+            if ( string.IsNullOrEmpty( value ) )
+            {
+                throw new InvalidOperationException( $"Missing required argument '{name}'." );
+            }
+
+            return value;
+        }
+
+        internal static string GetString( JObject args, string name )
+        {
+            JToken token = args?[name];
+
+            if ( token == null || token.Type == JTokenType.Null )
+            {
+                return null;
+            }
+
+            return token.ToObject<string>();
+        }
+
+        internal static bool GetBool( JObject args, string name )
+        {
+            JToken token = args?[name];
+
+            return token != null && token.Type != JTokenType.Null && token.ToObject<bool>();
+        }
+
+        internal static string[] GetStringArray( JObject args, string name )
+        {
+            JToken token = args?[name];
+
+            if ( token == null || token.Type != JTokenType.Array )
+            {
+                return null;
+            }
+
+            return token.Select( t => t.ToObject<string>() ).ToArray();
+        }
+
+        internal static int? GetInt( JObject args, string name )
+        {
+            JToken token = args?[name];
+
+            if ( token == null || token.Type == JTokenType.Null )
+            {
+                return null;
+            }
+
+            if ( token.Type == JTokenType.Integer )
+            {
+                return token.ToObject<int>();
+            }
+
+            string text = token.ToObject<string>();
+
+            return TryParseInt( text, out int value ) ? value : (int?) null;
+        }
+
+        internal static int RequireInt( JObject args, string name )
+        {
+            int? value = GetInt( args, name );
+
+            if ( value == null )
+            {
+                throw new InvalidOperationException( $"Missing or invalid required argument '{name}'." );
+            }
+
+            return value.Value;
+        }
+
+        internal static bool TryParseInt( string text, out int value )
+        {
+            text = text?.Trim();
+
+            if ( string.IsNullOrEmpty( text ) )
+            {
+                value = 0;
+                return false;
+            }
+
+            if ( text.StartsWith( "0x", StringComparison.OrdinalIgnoreCase ) )
+            {
+                return int.TryParse( text.Substring( 2 ), NumberStyles.HexNumber, CultureInfo.InvariantCulture,
+                    out value );
+            }
+
+            // Try hex without prefix if it contains a-f
+            if ( text.Any( c => c >= 'a' && c <= 'f' || c >= 'A' && c <= 'F' ) )
+            {
+                return int.TryParse( text, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out value );
+            }
+
+            return int.TryParse( text, out value );
+        }
+    }
+}

--- a/ClassicAssist/Mcp/McpTypes.cs
+++ b/ClassicAssist/Mcp/McpTypes.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace ClassicAssist.Mcp
+{
+    public sealed class JsonRpcRequest
+    {
+        [JsonProperty( "jsonrpc" )]
+        public string JsonRpc { get; set; } = "2.0";
+
+        [JsonProperty( "id", NullValueHandling = NullValueHandling.Ignore )]
+        public object Id { get; set; }
+
+        [JsonProperty( "method" )]
+        public string Method { get; set; }
+
+        [JsonProperty( "params", NullValueHandling = NullValueHandling.Ignore )]
+        public JToken Params { get; set; }
+    }
+
+    public sealed class JsonRpcResponse
+    {
+        [JsonProperty( "jsonrpc" )]
+        public string JsonRpc { get; set; } = "2.0";
+
+        [JsonProperty( "id" )]
+        public object Id { get; set; }
+
+        [JsonProperty( "result", NullValueHandling = NullValueHandling.Ignore )]
+        public object Result { get; set; }
+
+        [JsonProperty( "error", NullValueHandling = NullValueHandling.Ignore )]
+        public JsonRpcError Error { get; set; }
+    }
+
+    public sealed class JsonRpcError
+    {
+        [JsonProperty( "code" )]
+        public int Code { get; set; }
+
+        [JsonProperty( "message" )]
+        public string Message { get; set; }
+
+        [JsonProperty( "data", NullValueHandling = NullValueHandling.Ignore )]
+        public object Data { get; set; }
+    }
+
+    public sealed class McpTool
+    {
+        [JsonProperty( "name" )]
+        public string Name { get; set; }
+
+        [JsonProperty( "description" )]
+        public string Description { get; set; }
+
+        [JsonProperty( "inputSchema" )]
+        public JObject InputSchema { get; set; }
+    }
+
+    public sealed class CallToolResult
+    {
+        [JsonProperty( "content" )]
+        public List<McpContent> Content { get; set; } = new List<McpContent>();
+
+        [JsonProperty( "isError" )]
+        public bool IsError { get; set; }
+    }
+
+    public sealed class McpContent
+    {
+        [JsonProperty( "type" )]
+        public string Type { get; set; } = "text";
+
+        [JsonProperty( "text" )]
+        public string Text { get; set; }
+    }
+
+    public sealed class CallToolParams
+    {
+        [JsonProperty( "name" )]
+        public string Name { get; set; }
+
+        [JsonProperty( "arguments" )]
+        public JObject Arguments { get; set; }
+    }
+}

--- a/ClassicAssist/UI/ViewModels/OptionsTabViewModel.cs
+++ b/ClassicAssist/UI/ViewModels/OptionsTabViewModel.cs
@@ -7,6 +7,7 @@ using ClassicAssist.Data;
 using ClassicAssist.Data.Hotkeys;
 using ClassicAssist.Data.Macros.Commands;
 using ClassicAssist.DebugAdapter.Dap;
+using ClassicAssist.Mcp;
 using ClassicAssist.Misc;
 using ClassicAssist.Shared.Resources;
 using ClassicAssist.Shared.UI;
@@ -42,6 +43,12 @@ namespace ClassicAssist.UI.ViewModels
         public ICommand ToggleDebugAdapterCommand =>
             _toggleDebugAdapterCommand ??
             ( _toggleDebugAdapterCommand = new RelayCommand( ToggleDebugAdapter, o => true ) );
+
+        private ICommand _toggleMcpCommand;
+
+        public ICommand ToggleMcpCommand =>
+            _toggleMcpCommand ??
+            ( _toggleMcpCommand = new RelayCommand( ToggleMcp, o => true ) );
 
         public void Serialize( JObject json, bool global = false )
         {
@@ -134,6 +141,13 @@ namespace ClassicAssist.UI.ViewModels
             if ( DapServer.IsRunning )
             {
                 CurrentOptions.DebugAdapterPort = DapServer.Port;
+            }
+
+            CurrentOptions.McpEnabled = McpServer.IsRunning;
+
+            if ( McpServer.IsRunning )
+            {
+                CurrentOptions.McpPort = McpServer.Port;
             }
 
             ActionCommands.UseOnceList.Clear();
@@ -314,6 +328,37 @@ namespace ClassicAssist.UI.ViewModels
                 // Ensure any partially-initialised server is torn down before reverting the toggle.
                 DapServer.Shutdown();
                 CurrentOptions.DebugAdapterEnabled = false;
+                MessageBox.Show( e.Message, Strings.Error );
+            }
+        }
+
+        private void ToggleMcp( object obj )
+        {
+            try
+            {
+                if ( CurrentOptions.McpEnabled )
+                {
+                    int port = CurrentOptions.McpPort;
+
+                    if ( port < 1 || port > 65535 )
+                    {
+                        CurrentOptions.McpEnabled = false;
+                        MessageBox.Show( Strings.MCP_invalid_port, Strings.Error );
+                        return;
+                    }
+
+                    McpServer.Initialize( port );
+                }
+                else
+                {
+                    McpServer.Shutdown();
+                }
+            }
+            catch ( Exception e )
+            {
+                // Ensure any partially-initialised server is torn down before reverting the toggle.
+                McpServer.Shutdown();
+                CurrentOptions.McpEnabled = false;
                 MessageBox.Show( e.Message, Strings.Error );
             }
         }

--- a/ClassicAssist/UI/Views/OptionsTabControl.xaml
+++ b/ClassicAssist/UI/Views/OptionsTabControl.xaml
@@ -199,6 +199,16 @@
                                          IsEnabled="{Binding CurrentOptions.DebugAdapterEnabled, Converter={StaticResource InverseBooleanConverter}}" />
                             </controls:OptionedCheckBoxControl.ChildContent>
                         </controls:OptionedCheckBoxControl>
+                        <controls:OptionedCheckBoxControl IsChecked="{Binding CurrentOptions.McpEnabled}"
+                                                          Command="{Binding ToggleMcpCommand}"
+                                                          Content="{x:Static resources:Strings.MCP}"
+                                                          ToolTip="{x:Static resources:Strings.MCP_tooltip}">
+                            <controls:OptionedCheckBoxControl.ChildContent>
+                                <TextBox Width="50" Margin="5,0,0,0"
+                                         Text="{Binding CurrentOptions.McpPort}"
+                                         IsEnabled="{Binding CurrentOptions.McpEnabled, Converter={StaticResource InverseBooleanConverter}}" />
+                            </controls:OptionedCheckBoxControl.ChildContent>
+                        </controls:OptionedCheckBoxControl>
                     </StackPanel>
                 </GroupBox>
             </controls:ResponsiveGrid.Items>


### PR DESCRIPTION
## Summary

Adds a Model Context Protocol (MCP) server so AI agents can inspect and control ClassicAssist macros and game state over a loopback TCP/HTTP endpoint.

## Features

- **Streamable HTTP MCP server** bound to \127.0.0.1\ (default port 4713), with a **session-only** enable toggle in Options (not persisted to the profile), mirroring the existing DAP debug server pattern.
- **Macro tools**: listMacros, getMacro, createMacro, updateMacro, deleteMacro, playMacro (brings client to front, waits and reports errors), stopMacro, stopAllMacros, getMacroStatus.
- **Game-state tools**: getPlayer, getBackpack, getContainer, getItems, getMobiles, getTileInfo, getItemInfo, getCliloc, getJournal, listGumps, getGumpLayout.
- **Generic command tools**: invokeCommand (invoke any macro command by reflection) + listCommands (with descriptions/examples/per-parameter hints).
- **Agent tools**: listAgents + getAgent (dress, organizer, friends, vendor buy, scavenger, trap pouch, autoloot) for querying current entries (e.g. is a serial on the friends list).

## Notes

- All user-facing strings follow existing conventions; MCP acronym kept uppercase per repo style.
- Session-only and loopback-only by design; not exposed on the network.
